### PR TITLE
Fix Copilot review comments from PR #23

### DIFF
--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -1,4 +1,4 @@
-`# Getting Started
+# Getting Started
 
 This guide will help you install and start using Wolfgang.Extensions.ICollection in your .NET projects.
 

--- a/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
+++ b/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
@@ -61,7 +61,7 @@ public static class ICollectionExtensions
     /// numbers.AddRange(new[] { 3, 4, 5 });
     /// // numbers now contains: 1, 2, 3, 4, 5
     /// 
-    /// // Add items from LINQ query results
+    /// // Add items from LINQ query results (requires using System.Linq)
     /// var evenNumbers = Enumerable.Range(1, 10).Where(n => n % 2 == 0);
     /// ICollection&lt;int&gt; myCollection = new List&lt;int&gt;();
     /// myCollection.AddRange(evenNumbers);
@@ -70,12 +70,12 @@ public static class ICollectionExtensions
     /// </example>
     public static void AddRange<T>(this ICollection<T> source, IEnumerable<T> items)
     {
-        if (source == null)
+        if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
 
-        if (items == null)
+        if (items is null)
         {
             throw new ArgumentNullException(nameof(items));
         }


### PR DESCRIPTION
## Summary
Addresses 3 of 12 Copilot review comments from PR #23:

- **`is null` pattern matching** — changed `== null` to `is null` in `ICollectionExtensions.cs` to match editorconfig preference
- **Stray backtick** — removed leading backtick from `getting-started.md` H1 heading that broke rendering
- **XML doc example** — added LINQ using note to make the code example self-contained

### Comments not addressed (disagree/out of scope):
- **xunit.runner.visualstudio v3.x with xUnit v2** (7 comments) — this is an intentional per-TFM version strategy used across all Wolfgang packages. v3.x runner works with xUnit v2 on newer TFMs.
- **docfx.yaml fallback messaging** — CI workflow concern, current behavior is acceptable

## Test plan
- [x] Build passes (`dotnet build --configuration Release`)
- [x] All 15 tests pass on net8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)