### PR TITLE
Align workflow job names with branch protection ruleset

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,39 +1,81 @@
 # Sequential PR validation workflow with coverage gating
 # Stage 1: Linux tests with 90% coverage requirement
-# Stage 2: Windows and macOS tests (only if Linux passes)
-# Stage 3: .NET Framework 4.x tests on Windows (only if Stage 2 passes)
+# Stage 2: Windows .NET (5.0-10.0) and .NET Framework (4.6.2-4.8.1) tests (only if Linux passes)
+# Stage 3: macOS tests (only if Stage 2 passes)
+#
+# SECURITY NOTE:
+# - Uses pull_request_target to run workflow from the trusted main branch, not from the PR branch
+# - This prevents malicious workflow YAML changes in untrusted PR branches from taking effect
+# - All checkout steps use PR refs (refs/pull/*/head) to check out PR code from the base repo
+# - persist-credentials: false prevents the checkout token from being written to git config for subsequent git commands
+#   (it does NOT, by itself, prevent steps from accessing github.token / GITHUB_TOKEN if you explicitly expose it)
+# - Default GITHUB_TOKEN permissions are restricted to read-only repository contents to limit impact if exposed
 
-name: PR Checks v2 (Gated)
+name: PR Checks v3 (Gated)
 
 permissions:
   contents: read
+
+env:
+  CODECOV_MINIMUM: 90
   
 on:
-  pull_request: 
-    branches: 
+  pull_request_target:  # Runs from the main branch, not from PR branch
+    branches:
       - main
-      - develop
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
 jobs:
+  # ============================================================================
+  # DETECTION: Check if .csproj files exist
+  # ============================================================================
+  detect-projects:
+    name: "Detect .NET Projects"
+    runs-on: ubuntu-latest
+    if: github.repository != 'Chris-Wolfgang/repo-template'
+    outputs:
+      has-projects: ${{ steps.check-projects.outputs.has-projects }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+      
+      - name: Check for .NET project files
+        id: check-projects
+        run: |
+          if git ls-files '*.csproj' '*.vbproj' '*.fsproj' | grep -q .; then
+            echo "has-projects=true" >> $GITHUB_OUTPUT
+            echo "✅ Found .NET project files - .NET build and test jobs will run"
+          else
+            echo "has-projects=false" >> $GITHUB_OUTPUT
+            echo "ℹ️  No .NET project files found - skipping .NET build and test jobs"
+          fi
+
   # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
   # ============================================================================
   test-linux-core: 
     name: "Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate"
     runs-on:  ubuntu-latest
-    if: github.repository != 'Chris-Wolfgang/repo-template'
+    needs: detect-projects
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
     
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
 
-      # Fix for .NET 5.0 on Ubuntu 22.04+ - install libssl1.1
+      # Fix for .NET 5.0 on Ubuntu 22.04+ - install libssl1.1 from the focal-security
+      # repository so APT verifies the package via GPG instead of a plain wget download.
       - name: Install OpenSSL 1.1 for .NET 5.0
         run: |
-          wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-          sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
+          echo "deb http://security.ubuntu.com/ubuntu focal-security main" | sudo tee /etc/apt/sources.list.d/focal-security.list
+          sudo apt-get update -q
+          sudo apt-get install --yes libssl1.1
+          sudo rm /etc/apt/sources.list.d/focal-security.list
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -46,44 +88,85 @@ jobs:
             9.0.x
             10.0.x
 
-      - name: Restore and build (exclude .NET Framework 4.x projects)
+      - name: Restore and build (exclude .NET Framework-only projects)
         run: |
-          echo "Finding all projects in solution..."
+          echo "Finding .NET project files in repository (via find command)..."
           
-          # Get list of all projects from solution file
-          if [ -f "*.sln" ]; then
-            sln_file=$(ls *.sln | head -n 1)
-            echo "Using solution file: $sln_file"
-          fi
+          # Filter out projects that ONLY target .NET Framework 4.x
+          # Multi-targeting projects (e.g., net8.0;net48) will be INCLUDED
+          projects=()
+          project_found=false
           
-          # Find all .csproj, .vbproj, and .fsproj files
-          # Exclude those with 'dotnet4' or 'DotNet4' in the path (case-insensitive)
-          projects=$(find . -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) | grep -iv "dotnet4")
+          while IFS= read -r -d '' proj; do
+            project_found=true
+            # Check if project has any .NET 5+ target framework
+            # Look for: net5.0, net6.0, net7.0, net8.0, net9.0, net10.0, or netcoreapp, netstandard
+            if grep -qE '<TargetFramework[s]?>.*(net(5\.0|6\.0|7\.0|8\.0|9\.0|10\.0)|netcoreapp|netstandard)' "$proj"; then
+              projects+=("$proj")
+              echo "✓ Including: $proj (has .NET 5+ or .NET Core target)"
+            else
+              echo "⊘ Excluding: $proj (Framework-only, incompatible with Linux)"
+            fi
+          done < <(find . -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
           
-          if [ -z "$projects" ]; then
-            echo "No projects found!"
+          if [ "$project_found" = false ]; then
+            echo "❌ No .NET projects found."
+            echo "This should not occur as detect-projects already verified project existence."
             exit 1
           fi
           
+          if [ ${#projects[@]} -eq 0 ]; then
+            echo "❌ No compatible .NET projects found."
+            echo "All projects target only .NET Framework 4.x, which is incompatible with Linux."
+            exit 1
+          fi
+          
+          echo ""
           echo "=========================================="
-          echo "Projects to build (excluding .NET Framework 4.x):"
+          echo "Projects to build:"
           echo "=========================================="
-          echo "$projects"
+          printf '%s\n' "${projects[@]}"
           echo ""
           
           # Restore each project
           echo "Restoring projects..."
-          for proj in $projects; do
+          for proj in "${projects[@]}"; do
             echo "Restoring: $proj"
             dotnet restore "$proj" || exit 1
           done
           
           echo ""
           echo "Building projects..."
-          # Build each project
-          for proj in $projects; do
+          # Build each project, handling multi-targeting projects
+          # For multi-targeting projects, build only Linux-compatible frameworks (.NET 5.0+, .NET Core, .NET Standard)
+          for proj in "${projects[@]}"; do
             echo "Building: $proj"
-            dotnet build "$proj" --no-restore --configuration Release || exit 1
+            
+            # Extract target frameworks from the project file
+            # Support both <TargetFramework> (single) and <TargetFrameworks> (multiple)
+            frameworks=$(grep -oP '<TargetFramework[s]?>\K[^<]+' "$proj" | tr ';' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -E '^(net(5\.0|6\.0|7\.0|8\.0|9\.0|10\.0)|netcoreapp[0-9.]+|netstandard[0-9.]+)$' || true)
+            
+            if [ -z "$frameworks" ]; then
+              echo "⚠️  No Linux-compatible frameworks found in $proj"
+              continue
+            fi
+            
+            # Check if this is a multi-targeting project
+            framework_count=$(echo "$frameworks" | wc -l)
+            
+            if [ "$framework_count" -eq 1 ]; then
+              # Single target framework - build normally
+              echo "  Target framework: $frameworks"
+              dotnet build "$proj" --no-restore --configuration Release || exit 1
+            else
+              # Multi-targeting project - build each compatible framework separately
+              echo "  Target frameworks (multi-targeting): $(echo "$frameworks" | tr '\n' ' ')"
+              while IFS= read -r fw; do
+                [ -z "$fw" ] && continue
+                echo "  Building framework: $fw"
+                dotnet build "$proj" --no-restore --configuration Release --framework "$fw" || exit 1
+              done <<< "$frameworks"
+            fi
           done
           
           echo ""
@@ -91,10 +174,10 @@ jobs:
 
       - name: Run tests with coverage (.NET Core 5.0 - 10.0)
         run: |
-          # Find all test projects
-          test_projects=$(find ./tests -type f -name "*.csproj")
+          # Find all test projects (C#, VB.NET, F#)
+          mapfile -t test_projects < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \))
           
-          if [ -z "$test_projects" ]; then
+          if [ ${#test_projects[@]} -eq 0 ]; then
             echo "❌ No test projects found in ./tests directory!"
             exit 1
           fi
@@ -102,18 +185,30 @@ jobs:
           echo "=========================================="
           echo "Found test projects:"
           echo "=========================================="
-          echo "$test_projects"
+          printf '%s\n' "${test_projects[@]}"
           echo ""
           
-          # Test each framework individually to ensure all are tested
-          frameworks=(net5.0 net6.0 net7.0 net8.0 net9.0 net10.0)
-          
-          for test_proj in $test_projects; do
+          for test_proj in "${test_projects[@]}"; do
             echo "=========================================="
             echo "Testing project: $test_proj"
             echo "=========================================="
             
-            for fw in "${frameworks[@]}"; do
+            # Extract target frameworks from the project file
+            # Support both <TargetFramework> (single) and <TargetFrameworks> (multiple)
+            frameworks=$(grep -oP '<TargetFramework[s]?>\K[^<]+' "$test_proj" | tr ';' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -E '^net(5\.0|6\.0|7\.0|8\.0|9\.0|10\.0)$' || true)
+            
+            if [ -z "$frameworks" ]; then
+              echo "⊘ Skipping: No compatible .NET 5.0-10.0 target frameworks found"
+              echo ""
+              continue
+            fi
+            
+            echo "Target frameworks: $(echo "$frameworks" | tr '\n' ' ')"
+            echo ""
+            
+            # Test each framework that the project actually targets
+            while IFS= read -r fw; do
+              [ -z "$fw" ] && continue
               echo "Testing framework: $fw"
               
               dotnet test "$test_proj" \
@@ -122,14 +217,27 @@ jobs:
                 --collect:"XPlat Code Coverage" \
                 --results-directory "./TestResults" \
                 --logger "console;verbosity=minimal" || exit 1
-            done
+            done <<< "$frameworks"
             echo ""
           done
 
+      - name: Check for coverage files
+        id: check-coverage
+        run: |
+          if find TestResults -type f -name "coverage.cobertura.xml" 2>/dev/null | grep -q .; then
+            echo "has-coverage=true" >> $GITHUB_OUTPUT
+            echo "✅ Coverage files found"
+          else
+            echo "has-coverage=false" >> $GITHUB_OUTPUT
+            echo "ℹ️  No coverage files found - skipping coverage report generation"
+          fi
+
       - name: Install ReportGenerator
+        if: steps.check-coverage.outputs.has-coverage == 'true'
         run: dotnet tool install -g dotnet-reportgenerator-globaltool
 
       - name: Generate coverage report
+        if: steps.check-coverage.outputs.has-coverage == 'true'
         run: |
           reportgenerator \
             -reports:"TestResults/**/coverage.cobertura.xml" \
@@ -137,6 +245,7 @@ jobs:
             -reporttypes:"Html;TextSummary;MarkdownSummaryGithub;CsvSummary"
 
       - name: Enforce 90% coverage threshold
+        if: steps.check-coverage.outputs.has-coverage == 'true'
         run: |
           if [ ! -f CoverageReport/Summary.txt ]; then
             echo "❌ Coverage report not generated!"
@@ -148,7 +257,7 @@ jobs:
           echo ""
           
           failed_projects=""
-          threshold=90
+          threshold=${CODECOV_MINIMUM:-90}
           
           while read -r line; do
             # Match lines with module names and percentages
@@ -203,17 +312,20 @@ jobs:
             tests/**/bin/Release
 
   # ============================================================================
-  # STAGE 2: Windows & macOS - .NET Core/5+ Tests (Gated by Stage 1)
+  # STAGE 2: Windows - All .NET Tests (Gated by Stage 1)
   # ============================================================================
-  test-windows-core:
-    name: "Stage 2a: Windows Tests (.NET 5.0-10.0)"
+  test-windows:
+    name: "Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)"
     runs-on: windows-latest
-    needs: test-linux-core
-    if: github.repository != 'Chris-Wolfgang/repo-template'
+    needs: [detect-projects, test-linux-core]
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
     
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -232,12 +344,14 @@ jobs:
       - name: Build solution
         run: dotnet build --no-restore --configuration Release
 
-      - name: Run tests (.NET Core 5.0 - 10.0)
+      - name: Run all .NET tests (.NET 5.0-10.0 and Framework 4.6.2-4.8.1)
         shell: pwsh
         run: |
-          $testProjects = Get-ChildItem -Path './tests' -Recurse -Filter '*.csproj'
+          $ErrorActionPreference = 'Stop'
           
-          if ($testProjects.Count -eq 0) {
+          $testProjects = @(Get-ChildItem -Path './tests/*' -Recurse -File -Include '*.csproj','*.vbproj','*.fsproj')
+          
+          if (@($testProjects).Count -eq 0) {
             Write-Error "❌ No test projects found in ./tests directory!"
             exit 1
           }
@@ -248,15 +362,37 @@ jobs:
           $testProjects | ForEach-Object { Write-Host $_.FullName -ForegroundColor White }
           Write-Host ""
           
-          $frameworks = @('net5.0', 'net6.0', 'net7.0', 'net8.0', 'net9.0', 'net10.0')
-          
           foreach ($testProj in $testProjects) {
             Write-Host "==========================================" -ForegroundColor Cyan
             Write-Host "Testing project: $($testProj.FullName)" -ForegroundColor Cyan
             Write-Host "==========================================" -ForegroundColor Cyan
             
+            # Extract target frameworks from the project file
+            # Support both <TargetFramework> (single) and <TargetFrameworks> (multiple)
+            $content = Get-Content $testProj.FullName -Raw
+            $tfmMatch = [regex]::Match($content, '<TargetFramework[s]?>([^<]+)</TargetFramework[s]?>')
+            
+            if (-not $tfmMatch.Success) {
+              Write-Host "⊘ Skipping: No target frameworks found" -ForegroundColor Yellow
+              Write-Host ""
+              continue
+            }
+            
+            # Split by semicolon for multi-targeting projects
+            $frameworks = $tfmMatch.Groups[1].Value -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ -match '^net(5\.0|6\.0|7\.0|8\.0|9\.0|10\.0|462|47|471|472|48|481)$' }
+            
+            if ($frameworks.Count -eq 0) {
+              Write-Host "⊘ Skipping: No compatible .NET 5.0-10.0 or Framework 4.6.2-4.8.1 target frameworks found" -ForegroundColor Yellow
+              Write-Host ""
+              continue
+            }
+            
+            Write-Host "Target frameworks: $($frameworks -join ', ')" -ForegroundColor White
+            Write-Host ""
+            
+            # Test each framework that the project actually targets
             foreach ($fw in $frameworks) {
-              Write-Host "Testing framework:  $fw" -ForegroundColor Yellow
+              Write-Host "Testing framework: $fw" -ForegroundColor Yellow
               
               dotnet test $testProj.FullName `
                 --configuration Release `
@@ -271,15 +407,21 @@ jobs:
             Write-Host ""
           }
 
-  test-macos-core:  
-    name: "Stage 2b: macOS Tests (.NET 6.0-10.0)"
+  # ============================================================================
+  # STAGE 3: macOS Tests (Gated by Stage 2)
+  # ============================================================================
+  test-macos-core:
+    name: "Stage 3: macOS Tests (.NET 6.0-10.0)"
     runs-on: macos-latest
-    needs: test-linux-core
-    if: github.repository != 'Chris-Wolfgang/repo-template'
+    needs: [detect-projects, test-windows]
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
     
     steps:
-      - name:  Checkout code
+      - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -291,38 +433,86 @@ jobs:
             9.0.x
             10.0.x
 
-      - name: Restore and build (exclude .NET Framework 4.x projects)
+      - name: Restore and build (exclude .NET Framework-only projects)
         run: |
-          echo "Finding all projects in solution..."
+          echo "Enumerating tracked .NET project files (git ls-files)..."
           
-          # Find all .csproj, .vbproj, and .fsproj files
-          # Exclude those with 'dotnet4' or 'DotNet4' in the path (case-insensitive)
-          projects=$(find . -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) | grep -iv "dotnet4")
+          # Filter out projects that ONLY target .NET Framework 4.x
+          # Multi-targeting projects (e.g., net8.0;net48) will be INCLUDED
+          projects=()
+          project_found=false
           
-          if [ -z "$projects" ]; then
-            echo "No projects found!"
+          while IFS= read -r -d '' proj; do
+            project_found=true
+            # Check if project has any .NET 6+ target framework (macOS ARM64 compatible)
+            # Look for: net6.0, net7.0, net8.0, net9.0, net10.0
+            if grep -qE '<TargetFramework[s]?>.*net(6\.0|7\.0|8\.0|9\.0|10\.0)' "$proj"; then
+              projects+=("$proj")
+              echo "✓ Including: $proj (has .NET 6+ target)"
+            else
+              echo "⊘ Excluding: $proj (no .NET 6+ target, incompatible with macOS ARM64)"
+            fi
+          done < <(git ls-files -z -- '*.csproj' '*.vbproj' '*.fsproj')
+          
+          if [ "$project_found" = false ]; then
+            echo "❌ No .NET projects found."
+            echo "This should not occur as detect-projects already verified project existence."
             exit 1
           fi
           
+          if [ ${#projects[@]} -eq 0 ]; then
+            echo "❌ No compatible .NET projects found."
+            echo "All projects lack .NET 6+ targets, which are required for macOS ARM64."
+            exit 1
+          fi
+          
+          echo ""
           echo "=========================================="
-          echo "Projects to build (excluding .NET Framework 4.x):"
+          echo "Projects to build (excluding .NET Framework-only projects):"
           echo "=========================================="
-          echo "$projects"
+          printf '%s\n' "${projects[@]}"
           echo ""
           
           # Restore each project
           echo "Restoring projects..."
-          for proj in $projects; do
+          for proj in "${projects[@]}"; do
             echo "Restoring: $proj"
             dotnet restore "$proj" || exit 1
           done
           
           echo ""
           echo "Building projects..."
-          # Build each project
-          for proj in $projects; do
+          # Build each project, handling multi-targeting projects
+          # For multi-targeting projects, build only macOS ARM64-compatible frameworks (net6.0-10.0)
+          for proj in "${projects[@]}"; do
             echo "Building: $proj"
-            dotnet build "$proj" --no-restore --configuration Release || exit 1
+            
+            # Extract target frameworks from the project file
+            # Support both <TargetFramework> (single) and <TargetFrameworks> (multiple)
+            # Trim whitespace from each framework before filtering
+            frameworks=$(sed -n -E 's/.*<TargetFrameworks?>[[:space:]]*>([^<]+)<\/TargetFrameworks?>.*/\1/p' "$proj" | tr ';' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -E '^net(6\.0|7\.0|8\.0|9\.0|10\.0)$' || true)
+            
+            if [ -z "$frameworks" ]; then
+              echo "⚠️  No macOS ARM64-compatible frameworks found in $proj"
+              continue
+            fi
+            
+            # Check if this is a multi-targeting project
+            framework_count=$(echo "$frameworks" | wc -l)
+            
+            if [ "$framework_count" -eq 1 ]; then
+              # Single target framework - build normally
+              echo "  Target framework: $frameworks"
+              dotnet build "$proj" --no-restore --configuration Release || exit 1
+            else
+              # Multi-targeting project - build each compatible framework separately
+              echo "  Target frameworks (multi-targeting): $(echo "$frameworks" | tr '\n' ' ')"
+              while IFS= read -r fw; do
+                [ -z "$fw" ] && continue
+                echo "  Building framework: $fw"
+                dotnet build "$proj" --no-restore --configuration Release --framework "$fw" || exit 1
+              done <<< "$frameworks"
+            fi
           done
           
           echo ""
@@ -330,10 +520,13 @@ jobs:
 
       - name:  Run tests (.NET 6.0 - 10.0 only - ARM64 compatible)
         run: |
-          # Find all test projects
-          test_projects=$(find ./tests -type f -name "*.csproj")
+          # Find all test projects (C#, VB.NET, F#)
+          test_projects=()
+          while IFS= read -r file; do
+          test_projects+=("$file")
+          done < <(find ./tests -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \))          
           
-          if [ -z "$test_projects" ]; then
+          if [ ${#test_projects[@]} -eq 0 ]; then
             echo "❌ No test projects found in ./tests directory!"
             exit 1
           fi
@@ -341,25 +534,38 @@ jobs:
           echo "=========================================="
           echo "Found test projects:"
           echo "=========================================="
-          echo "$test_projects"
+          printf '%s\n' "${test_projects[@]}"
           echo ""
           
-          # Skip .NET Core 5.0 and .NET 5.0 - no ARM64 support on macOS
-          frameworks=(net6.0 net7.0 net8.0 net9.0 net10.0)
-          
-          for test_proj in $test_projects; do
+          for test_proj in "${test_projects[@]}"; do
             echo "=========================================="
             echo "Testing project: $test_proj"
             echo "=========================================="
             
-            for fw in "${frameworks[@]}"; do
+            # Extract target frameworks from the project file
+            # Support both <TargetFramework> (single) and <TargetFrameworks> (multiple)
+            # Only include .NET 6.0+ (ARM64 compatible on macOS)
+            frameworks=$(grep -Eo '<TargetFrameworks?>[^<]+' "$test_proj" | sed -E 's/<TargetFrameworks?>//' | tr ';' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -E '^net(6\.0|7\.0|8\.0|9\.0|10\.0)$' || true)
+            
+            if [ -z "$frameworks" ]; then
+              echo "⊘ Skipping: No compatible .NET 6.0-10.0 target frameworks found (ARM64 required)"
+              echo ""
+              continue
+            fi
+            
+            echo "Target frameworks: $(echo "$frameworks" | tr '\n' ' ')"
+            echo ""
+            
+            # Test each framework that the project actually targets
+            while IFS= read -r fw; do
+              [ -z "$fw" ] && continue
               echo "Testing framework: $fw"
               
               dotnet test "$test_proj" \
                 --configuration Release \
                 --framework "$fw" \
                 --logger "console;verbosity=normal" || exit 1
-            done
+            done <<< "$frameworks"
             echo ""
           done
 
@@ -383,83 +589,21 @@ jobs:
           echo "  - .NET 10.0 ✅"
           echo ""
           echo ".NET Core 5.0 are tested on Linux and Windows"
+          echo ""
 
-  # ============================================================================
-  # STAGE 3: Windows - .NET Framework 4.x Tests (Gated by Stage 2)
-  # ============================================================================
-  test-windows-framework: 
-    name: "Stage 3: Windows .NET Framework Tests (4.6.2-4.8.1)"
-    runs-on: windows-latest
-    needs: [test-windows-core, test-macos-core]
-    if: github.repository != 'Chris-Wolfgang/repo-template'
-    
-    steps: 
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            8.0.x
-
-      - name: Restore dependencies
-        run: dotnet restore
-
-      - name: Build solution
-        run: dotnet build --no-restore --configuration Release
-
-      - name:  Run .NET Framework tests (4.6.2 - 4.8.1)
-        shell: pwsh
+      - name: Summarize pipeline result
         run: |
-          $testProjects = Get-ChildItem -Path './tests' -Recurse -Filter '*.csproj'
-          
-          if ($testProjects.Count -eq 0) {
-            Write-Error "❌ No test projects found in ./tests directory!"
-            exit 1
-          }
-          
-          Write-Host "==========================================" -ForegroundColor Cyan
-          Write-Host "Found test projects:" -ForegroundColor Cyan
-          Write-Host "==========================================" -ForegroundColor Cyan
-          $testProjects | ForEach-Object { Write-Host $_.FullName -ForegroundColor White }
-          Write-Host ""
-          
-          $frameworks = @('net462', 'net472', 'net48', 'net481')
-          
-          foreach ($testProj in $testProjects) {
-            Write-Host "==========================================" -ForegroundColor Cyan
-            Write-Host "Testing project: $($testProj.FullName)" -ForegroundColor Cyan
-            Write-Host "==========================================" -ForegroundColor Cyan
-            
-            foreach ($fw in $frameworks) {
-              Write-Host "Testing framework: $fw" -ForegroundColor Yellow
-              
-              dotnet test $testProj.FullName `
-                --configuration Release `
-                --framework $fw `
-                --logger "console;verbosity=normal"
-              
-              if ($LASTEXITCODE -ne 0) {
-                Write-Error "Tests failed for $fw in $($testProj.Name)"
-                exit 1
-              }
-            }
-            Write-Host ""
-          }
-          
-          Write-Host ""
-          Write-Host "==========================================" -ForegroundColor Green
-          Write-Host "✅ ALL STAGES PASSED" -ForegroundColor Green
-          Write-Host "==========================================" -ForegroundColor Green
-          Write-Host "Stage 1: Linux tests + 90% coverage ✅" -ForegroundColor Green
-          Write-Host "Stage 2: Windows & macOS tests ✅" -ForegroundColor Green
-          Write-Host "Stage 3: .NET Framework 4.x tests ✅" -ForegroundColor Green
-          Write-Host ""
-          Write-Host "PR is ready to merge! 🎉" -ForegroundColor Green
+          echo "=========================================="
+          echo "✅ ALL STAGES PASSED"
+          echo "=========================================="
+          echo "Stage 1: Linux tests + 90% coverage ✅"
+          echo "Stage 2: Windows .NET Core & .NET Framework tests ✅"
+          echo "Stage 3: macOS tests ✅"
+          echo ""
+          echo "PR is ready to merge! 🎉"
 
   # ============================================================================
-  # Security Scan (Runs in parallel with tests)
+  # Security Scan (Runs in parallel, independently of .NET jobs)
   # ============================================================================
   security-scan:
     name: "Security Scan (DevSkim)"
@@ -469,18 +613,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
 
       - name: Install DevSkim CLI
         run: dotnet tool install --global Microsoft.CST.DevSkim.CLI
 
       - name: Run DevSkim security scan
-        continue-on-error: true
         run: |
           devskim analyze \
             --source-code . \
             --file-format text \
             --output-file devskim-results.txt \
-            -E \
             --ignore-rule-ids DS176209 \
             --ignore-globs "**/api/**,**/CoverageReport/**,**/TestResults/**"
 
@@ -495,7 +640,8 @@ jobs:
             echo ""
             
             if grep -qi "error\|critical\|high" devskim-results.txt; then
-              echo "⚠️ Security issues detected - review required"
+              echo "❌ Security issues detected - review required"
+              exit 1
             else
               echo "✅ No critical security issues found"
             fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,20 +1,27 @@
-name: Release on Version Tag
+name: Release on Published Release
+
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types: [published]
 
 permissions:
-  contents: read
+  contents: read  # Default to read-only; individual jobs declare write where required
+
+env:
+  CODECOV_MINIMUM: 90
 
 jobs:
-  build-and-test:
-    name: Build and Test
+  # Streamlined validation: All frameworks, Windows only
+  validate-release:
+    name: Validate Release Build
     runs-on: windows-latest
+    if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -33,32 +40,261 @@ jobs:
       - name: Build Solution (Release)
         run: dotnet build --no-restore --configuration Release
 
-      - name: Run tests for all test projects
+      - name: Run multi-framework tests with coverage
         shell: pwsh
         run: |
-          Get-ChildItem -Path './tests' -Recurse -Filter '*Test*.csproj' | ForEach-Object {
-            Write-Host "Running tests for $($_.FullName)"
-            dotnet test $_.FullName --no-build --configuration Release
-            if ($LASTEXITCODE -ne 0) {
-              Write-Error "Tests failed for $($_.FullName)"
-              exit $LASTEXITCODE
+          $testProjects = Get-ChildItem -Path './tests' -Recurse -Filter '*Test*.csproj'
+          
+          if ($testProjects.Count -eq 0) {
+            Write-Error "❌ No test projects found - release requires tests to validate quality"
+            exit 1
+          }
+          
+          foreach ($testProj in $testProjects) {
+            Write-Host "==========================================" -ForegroundColor Cyan
+            Write-Host "Testing project: $($testProj.Name)" -ForegroundColor Cyan
+            Write-Host "==========================================" -ForegroundColor Cyan
+            
+            # Parse the project file to extract target frameworks
+            try {
+              [xml]$projectXml = Get-Content $testProj.FullName
+            } catch {
+              Write-Error "❌ Failed to parse project file $($testProj.Name): $_"
+              exit 1
+            }
+            
+            # Search all PropertyGroup elements for TargetFramework(s)
+            $targetFramework = $null
+            $targetFrameworks = $null
+            foreach ($propGroup in $projectXml.Project.PropertyGroup) {
+              if ($propGroup.TargetFrameworks) {
+                $targetFrameworks = $propGroup.TargetFrameworks
+                break
+              } elseif ($propGroup.TargetFramework) {
+                $targetFramework = $propGroup.TargetFramework
+                break
+              }
+            }
+            
+            # Determine which frameworks this project targets
+            $frameworks = @()
+            if ($targetFrameworks) {
+              # Multiple frameworks (semicolon-separated)
+              $frameworks = $targetFrameworks -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+              if ($frameworks.Count -eq 0) {
+                Write-Error "❌ TargetFrameworks property in $($testProj.Name) is empty or malformed"
+                exit 1
+              }
+            } elseif ($targetFramework) {
+              # Single framework
+              $frameworks = @($targetFramework.Trim())
+              if (-not $frameworks[0]) {
+                Write-Error "❌ TargetFramework property in $($testProj.Name) is empty"
+                exit 1
+              }
+            } else {
+              # If no TargetFramework/TargetFrameworks are defined directly in the project file,
+              # attempt to resolve them via MSBuild (to account for Directory.Build.props, imports, etc.).
+              Write-Host "No TargetFramework or TargetFrameworks found directly in $($testProj.Name); querying MSBuild..." -ForegroundColor Yellow
+              
+              $msbuildOutput = @()
+              $msbuildExitCode = 0
+              foreach ($prop in @("TargetFrameworks", "TargetFramework")) {
+                $result = dotnet msbuild $testProj.FullName /nologo "-getProperty:$prop" 2>&1
+                if ($LASTEXITCODE -ne 0) {
+                  $msbuildExitCode = $LASTEXITCODE
+                }
+                if ($result) {
+                  $msbuildOutput += $result
+                }
+              }
+              
+              if ($msbuildExitCode -ne 0) {
+                # MSBuild query failed, fall back to running tests without explicit --framework
+                Write-Warning "MSBuild query failed for $($testProj.Name). Tests will run without explicit --framework."
+                $frameworks = @('')
+              } else {
+                # MSBuild succeeded, parse the output
+                $resolvedFrameworks = @()
+                foreach ($line in $msbuildOutput) {
+                  if ([string]::IsNullOrWhiteSpace($line)) {
+                    continue
+                  }
+                  
+                  # Expect lines like "TargetFrameworks=net7.0;net8.0" or "TargetFramework=net8.0"
+                  # Support both '=' and ':' separators for different MSBuild output formats
+                  if ($line -match '^\s*TargetFrameworks\s*[:=]\s*(.+)$') {
+                    $propertyValue = $Matches[1].Trim()
+                    $resolvedFrameworks = $propertyValue -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+                    break
+                  } elseif ($line -match '^\s*TargetFramework\s*[:=]\s*(.+)$') {
+                    $propertyValue = $Matches[1].Trim()
+                    if ($propertyValue) {
+                      $resolvedFrameworks = @($propertyValue)
+                    }
+                    
+                    if ($resolvedFrameworks.Count -gt 0) {
+                      break
+                    }
+                  }
+                }
+                
+                if ($resolvedFrameworks.Count -gt 0) {
+                  $frameworks = $resolvedFrameworks
+                } else {
+                  Write-Warning "MSBuild query returned no target frameworks for $($testProj.Name). Tests will run without explicit --framework."
+                  $frameworks = @('')
+                }
+              }
+            }
+            
+            Write-Host "Detected frameworks: $($frameworks -join ', ')" -ForegroundColor Cyan
+            
+            foreach ($fw in $frameworks) {
+              if ([string]::IsNullOrWhiteSpace($fw)) {
+                Write-Host "Testing project $($testProj.Name) without explicit --framework (using SDK/MSBuild defaults)" -ForegroundColor Yellow
+                
+                # When framework cannot be determined, run tests once without specifying --framework.
+                # Collect coverage in this case to avoid missing data due to unknown TFM.
+                dotnet test $testProj.FullName `
+                  --configuration Release `
+                  --no-build `
+                  --no-restore `
+                  --collect:"XPlat Code Coverage" `
+                  --results-directory "./TestResults" `
+                  --logger "console;verbosity=minimal"
+                
+                if ($LASTEXITCODE -ne 0) {
+                  Write-Error "❌ Tests failed (no explicit TargetFramework) in $($testProj.Name)"
+                  exit $LASTEXITCODE
+                }
+                
+                continue
+              }
+              
+              Write-Host "Testing framework: $fw" -ForegroundColor Yellow
+              
+              # Collect coverage only for .NET 5.0+ TFMs; still run tests for all frameworks
+              if ($fw -match '^net([5-9]|[1-9][0-9]+)\.') {
+                dotnet test $testProj.FullName `
+                  --configuration Release `
+                  --framework $fw `
+                  --no-build `
+                  --no-restore `
+                  --collect:"XPlat Code Coverage" `
+                  --results-directory "./TestResults" `
+                  --logger "console;verbosity=minimal"
+              } else {
+                # For older frameworks (e.g., netstandard, net4x, net3x, etc.), run tests without coverage
+                dotnet test $testProj.FullName `
+                  --configuration Release `
+                  --framework $fw `
+                  --no-build `
+                  --no-restore `
+                  --results-directory "./TestResults" `
+                  --logger "console;verbosity=minimal"
+              }
+              
+              if ($LASTEXITCODE -ne 0) {
+                if ($fw) {
+                  Write-Error "❌ Tests failed for $fw in $($testProj.Name)"
+                } else {
+                  Write-Error "❌ Tests failed in $($testProj.Name)"
+                }
+                exit $LASTEXITCODE
+              }
+            }
+            Write-Host ""
+          }
+          Write-Host "✅ All framework tests passed" -ForegroundColor Green
+
+      - name: Verify coverage threshold
+        shell: pwsh
+        run: |
+          # Check if coverage files exist
+          $coverageFiles = Get-ChildItem -Path "TestResults" -Recurse -Filter "coverage.cobertura.xml" -ErrorAction SilentlyContinue
+          
+          if ($coverageFiles.Count -eq 0) {
+            Write-Error "❌ No coverage files found - coverage data is required to enforce the 90% threshold"
+            exit 1
+          }
+          
+          dotnet tool install -g dotnet-reportgenerator-globaltool
+          
+          reportgenerator `
+            -reports:"TestResults/**/coverage.cobertura.xml" `
+            -targetdir:"CoverageReport" `
+            -reporttypes:"TextSummary;Html"
+          
+          Write-Host "==========================================" -ForegroundColor Cyan
+          Write-Host "Coverage Summary:" -ForegroundColor Cyan
+          Write-Host "==========================================" -ForegroundColor Cyan
+          Get-Content CoverageReport/Summary.txt
+          Write-Host ""
+          
+          # Parse coverage and enforce threshold per module (matching pr.yaml)
+          $summaryContent = Get-Content CoverageReport/Summary.txt
+          $threshold = if ($env:CODECOV_MINIMUM) { [int]$env:CODECOV_MINIMUM } else { 90 }
+          $failedModules = @()
+          $coverageFound = $false
+          
+          foreach ($line in $summaryContent) {
+            # Match lines with module names and percentages (skip Summary line)
+            if ($line -match '^([^ ]+)\s+.*\s+(\d+(?:\.\d+)?)%$' -and $line -notmatch '^Summary') {
+              $coverageFound = $true
+              $module = $matches[1]
+              $coverage = [decimal]$matches[2]
+              
+              Write-Host "Checking module: '$module' - Coverage: ${coverage}%" -ForegroundColor Cyan
+              
+              if ($coverage -lt $threshold) {
+                Write-Host "  ❌ FAIL: Below ${threshold}% threshold" -ForegroundColor Red
+                $failedModules += "$module (${coverage}%)"
+              } else {
+                Write-Host "  ✅ PASS: Meets ${threshold}% threshold" -ForegroundColor Green
+              }
             }
           }
+          
+          # Ensure we found and parsed coverage data
+          if (-not $coverageFound) {
+            Write-Error "❌ Failed to parse coverage data from Summary.txt - cannot enforce threshold"
+            exit 1
+          }
+          
+          if ($failedModules.Count -gt 0) {
+            Write-Host ""
+            Write-Host "==========================================" -ForegroundColor Red
+            Write-Host "❌ COVERAGE GATE FAILED" -ForegroundColor Red
+            Write-Host "==========================================" -ForegroundColor Red
+            Write-Host "Modules below ${threshold}% coverage: $($failedModules -join ', ')" -ForegroundColor Red
+            exit 1
+          }
+          
+          Write-Host ""
+          Write-Host "==========================================" -ForegroundColor Green
+          Write-Host "✅ All modules meet ${threshold}% coverage threshold" -ForegroundColor Green
+          Write-Host "==========================================" -ForegroundColor Green
 
-      - name: Upload test results
+      - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
-          path: '**/TestResults*.trx'
+          name: release-coverage
+          path: CoverageReport/
 
-  publish:
-    name: Pack and Publish NuGet
-    needs: build-and-test
+  # Pack and validate NuGet package
+  pack-and-validate:
+    name: Pack & Validate NuGet
+    needs: validate-release
     runs-on: windows-latest
+    outputs:
+      has-packages: ${{ steps.check-packages.outputs.has-packages }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -71,45 +307,286 @@ jobs:
             9.0.x
             10.0.x
 
-      - name: Restore dependencies
-        run: dotnet restore
+      - name: Restore and build
+        run: |
+          dotnet restore
+          dotnet build --no-restore --configuration Release
 
-      - name: Build Solution (Release)
-        run: dotnet build --no-restore --configuration Release
-
-      - name: Pack NuGet Packages
+      - name: Pack NuGet packages
+        id: check-packages
         shell: pwsh
         run: |
+          # Create output directory for NuGet packages
           $packagesPath = Join-Path $PWD 'nuget-packages'
           New-Item -ItemType Directory -Force -Path $packagesPath | Out-Null
 
-          Get-ChildItem -Path 'src' -Recurse -Filter '*.csproj' | ForEach-Object {
-            Write-Host "Packing $($_.FullName)"
-            dotnet pack $_.FullName --no-build --configuration Release --output $packagesPath
+          # Find all .csproj files in the src directory recursively
+          $projects = Get-ChildItem -Path 'src' -Recurse -Filter '*.csproj'
+          
+          # Handle case when no projects are found (e.g., template repository)
+          if ($projects.Count -eq 0) {
+            Write-Warning "No projects found in src/ directory - skipping package creation"
+            Write-Warning "Downstream publish and release jobs will be skipped"
+            # Create empty directory for artifact upload
+            New-Item -ItemType File -Path (Join-Path $packagesPath '.placeholder') -Force | Out-Null
+            # Set output to indicate no packages were created
+            "has-packages=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            exit 0
+          }
+          
+          # Iterate through each project and create NuGet package
+          foreach ($proj in $projects) {
+            Write-Host "📦 Packing $($proj.Name)" -ForegroundColor Cyan
+            dotnet pack $proj.FullName --no-build --configuration Release --output $packagesPath
+            
+            # Check if pack operation failed and exit with error
             if ($LASTEXITCODE -ne 0) {
-              Write-Error "dotnet pack failed for $($_.FullName)"
+              Write-Error "❌ Pack failed for $($proj.Name)"
               exit $LASTEXITCODE
             }
           }
+          
+          # Check whether any .nupkg files were actually created
+          $packages = Get-ChildItem -Path $packagesPath -Filter '*.nupkg' -ErrorAction SilentlyContinue
+          
+          if ($packages.Count -eq 0) {
+            Write-Warning "No .nupkg files were produced during packing - downstream publish and release jobs will be skipped"
+            "has-packages=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            exit 0
+          }
+          
+          # At least one package was created successfully
+          Write-Host "✅ NuGet packages created successfully" -ForegroundColor Green
+          "has-packages=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
-      - name: Upload NuGet packages as artifacts
+      - name: Smoke test NuGet package installation
+        shell: pwsh
+        run: |
+          $packages = Get-ChildItem -Path 'nuget-packages' -Filter '*.nupkg' -ErrorAction SilentlyContinue
+          
+          if ($packages.Count -eq 0) {
+            Write-Warning "No .nupkg files found - skipping smoke test"
+            exit 0
+          }
+          
+          # Helper to read package ID and version from the .nuspec inside a .nupkg
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          function Get-PackageMetadata {
+            param (
+              [Parameter(Mandatory = $true)]
+              [string] $NupkgPath
+            )
+
+            $zip = [System.IO.Compression.ZipFile]::OpenRead($NupkgPath)
+            try {
+              $nuspecEntry = $zip.Entries | Where-Object { $_.FullName -like '*.nuspec' } | Select-Object -First 1
+              if (-not $nuspecEntry) {
+                throw "No .nuspec file found in package '$NupkgPath'."
+              }
+
+              $stream = $nuspecEntry.Open()
+              try {
+                $reader = New-Object System.IO.StreamReader($stream)
+                $nuspecXml = [xml]$reader.ReadToEnd()
+                $id = $nuspecXml.package.metadata.id
+                $version = $nuspecXml.package.metadata.version
+
+                if ([string]::IsNullOrWhiteSpace($id) -or [string]::IsNullOrWhiteSpace($version)) {
+                  throw "Failed to read id/version from nuspec in '$NupkgPath'."
+                }
+
+                [PSCustomObject]@{
+                  Id      = $id
+                  Version = $version
+                }
+              }
+              finally {
+                $stream.Dispose()
+              }
+            }
+            finally {
+              $zip.Dispose()
+            }
+          }
+          
+          # Create temporary test project
+          $testDir = Join-Path $PWD 'package-smoke-test'
+          New-Item -ItemType Directory -Force -Path $testDir | Out-Null
+
+          # Restrict NuGet restores in this directory to the local package source only
+          $nugetConfigPath = Join-Path $testDir 'NuGet.config'
+          # Build NuGet.config content as array to avoid YAML parsing issues with here-strings
+          $nugetConfigContent = @(
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<configuration>'
+            '  <packageSources>'
+            '    <clear />'
+            '    <add key="local" value="../nuget-packages" />'
+            '  </packageSources>'
+            '  <packageSourceMapping>'
+            '    <packageSource key="local">'
+            '      <package pattern="*" />'
+            '    </packageSource>'
+            '  </packageSourceMapping>'
+            '</configuration>'
+          )
+          $nugetConfigContent | Set-Content -Path $nugetConfigPath -Encoding UTF8
+          
+          Push-Location $testDir
+          try {
+            dotnet new console -n SmokeTest -f net8.0
+            
+            # Try to install the newly created package(s)
+            foreach ($package in $packages) {
+              Write-Host "🧪 Smoke testing package: $($package.Name)" -ForegroundColor Yellow
+              
+              $metadata = Get-PackageMetadata -NupkgPath $package.FullName
+              $packageId = $metadata.Id
+              $packageVersion = $metadata.Version
+              
+              dotnet add SmokeTest/SmokeTest.csproj package $packageId --version $packageVersion --source '../nuget-packages'
+              
+              if ($LASTEXITCODE -ne 0) {
+                Write-Error "❌ Failed to install package $($package.Name)"
+                exit $LASTEXITCODE
+              }
+              
+              Write-Host "✅ Package $($package.Name) installed successfully" -ForegroundColor Green
+            }
+            
+            # Try to build the test project with the package
+            Write-Host "Building smoke test project..." -ForegroundColor Yellow
+            dotnet build SmokeTest/SmokeTest.csproj
+            
+            if ($LASTEXITCODE -ne 0) {
+              Write-Error "❌ Smoke test project failed to build with installed packages"
+              exit $LASTEXITCODE
+            }
+            
+            Write-Host "✅ Smoke test passed - packages are installable and buildable" -ForegroundColor Green
+            
+          } finally {
+            Pop-Location
+          }
+
+      - name: Upload NuGet packages
         uses: actions/upload-artifact@v4
-        with: 
+        with:
           name: nuget-packages
-          path: ./nuget-packages/*.nupkg
-          retention-days: 30
+          path: ./nuget-packages/
+          retention-days: 90
+          if-no-files-found: warn
 
-      - name: Publish NuGet Package
+  # Publish to NuGet (only if validation passed)
+  publish-nuget:
+    name: Publish to NuGet.org
+    needs: pack-and-validate
+    if: needs.pack-and-validate.outputs.has-packages == 'true'
+    runs-on: windows-latest
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            5.0.x
+            6.0.x
+            7.0.x
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Download packages
+        uses: actions/download-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./packages
+
+      - name: Validate NuGet API key
         shell: pwsh
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
-          $packagesPath = Join-Path $PWD 'nuget-packages'
-          Get-ChildItem -Path $packagesPath -Filter '*.nupkg' | ForEach-Object {
-            Write-Host "Publishing $($_.FullName)"
-            dotnet nuget push $_.FullName --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+          if ([string]::IsNullOrEmpty($env:NUGET_API_KEY)) {
+            Write-Error "❌ NUGET_API_KEY secret not configured!"
+            Write-Host "Please add it in: Repository Settings → Secrets and variables → Actions → New repository secret"
+            exit 1
+          }
+          Write-Host "✅ NUGET_API_KEY is configured" -ForegroundColor Green
+
+      - name: Publish to NuGet
+        shell: pwsh
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          $packages = Get-ChildItem -Path './packages' -Filter '*.nupkg' -ErrorAction SilentlyContinue
+          
+          if ($packages.Count -eq 0) {
+            Write-Warning "No .nupkg files found - nothing to publish"
+            exit 0
+          }
+          
+          foreach ($package in $packages) {
+            Write-Host "📤 Publishing $($package.Name) to NuGet.org" -ForegroundColor Cyan
+            
+            dotnet nuget push $package.FullName `
+              --api-key $env:NUGET_API_KEY `
+              --source https://api.nuget.org/v3/index.json `
+              --skip-duplicate
+            
+            # Exit code 0 = success, 409 would be duplicate (handled by --skip-duplicate flag)
             if ($LASTEXITCODE -ne 0) {
-              Write-Error "dotnet nuget push failed for $($_.FullName)"
+              Write-Error "❌ Failed to publish $($package.Name)"
               exit $LASTEXITCODE
             }
+            
+            Write-Host "✅ Successfully published $($package.Name)" -ForegroundColor Green
           }
+          
+          Write-Host ""
+          Write-Host "==========================================" -ForegroundColor Green
+          Write-Host "✅ All packages published to NuGet.org" -ForegroundColor Green
+          Write-Host "==========================================" -ForegroundColor Green
+
+  # Build and deploy versioned documentation via the shared docfx workflow
+  # Note: reusable workflow jobs called via `uses:` do not require `runs-on` in the caller
+  trigger-docs:
+    name: Build & Deploy Documentation
+    needs: validate-release
+    permissions:
+      contents: write  # Required by docfx.yaml to push to gh-pages branch
+    uses: ./.github/workflows/docfx.yaml
+    with:
+      version: ${{ github.event.release.tag_name }}
+
+  # Attach NuGet packages and coverage report to the GitHub Release page
+  update-release-artifacts:
+    name: Attach Artifacts to Release
+    needs: [validate-release, pack-and-validate, publish-nuget]
+    if: needs.pack-and-validate.outputs.has-packages == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to upload assets to the GitHub Release
+    steps:
+      - name: Download NuGet packages artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./nuget-packages
+
+      - name: Download coverage report artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-coverage
+          path: ./release-coverage
+
+      - name: Zip coverage report
+        run: zip -r release-coverage.zip ./release-coverage
+
+      - name: Attach artifacts to release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: |
+            ./nuget-packages/*.nupkg
+            release-coverage.zip
+


### PR DESCRIPTION
## Summary
- PR workflow job names (`Stage 2a`, `Stage 2b`, `Stage 3`) did not match the branch protection ruleset requirements (`Stage 2`, `Stage 3`), causing all PR checks to appear as never started
- Updates `pr.yaml` from v2 to v3 with correct job names and security improvements (`pull_request_target`, `persist-credentials: false`)
- Updates `release.yaml` to latest configuration with multi-framework coverage validation

## Ruleset alignment

| Ruleset expects | Old workflow (v2) | New workflow (v3) |
|---|---|---|
| `Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate` | ✓ matched | ✓ matches |
| `Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)` | ✗ was `Stage 2a` + `Stage 3` | ✓ matches |
| `Stage 3: macOS Tests (.NET 6.0-10.0)` | ✗ was `Stage 2b` | ✓ matches |
| `Security Scan (DevSkim)` | ✓ matched | ✓ matches |
| `Security Scan (CodeQL)` | ✗ missing | ✗ still missing — remove from ruleset or add workflow |

## Note
Since `pr.yaml` uses `pull_request_target`, it runs from the **main branch**. This PR's own checks will still use the old v2 workflow. Once merged, all subsequent PRs will use v3 with correct names.

## Test plan
- [ ] Merge this PR (may need temporary ruleset bypass since old workflow names don't match)
- [ ] Open a test PR and verify all 4 checks appear and run
- [ ] Address `Security Scan (CodeQL)` — either add a CodeQL workflow or remove from ruleset

🤖 Generated with [Claude Code](https://claude.com/claude-code)