### PR TITLE
Update Repo - 005 - Add build-all-versions workflow

### DIFF
--- a/.github/workflows/build-all-versions.yaml
+++ b/.github/workflows/build-all-versions.yaml
@@ -76,6 +76,8 @@ jobs:
           )
           Write-Host "Discovered $($versions.Count) version tag(s): $($versions -join ', ')"
 
+          $failedVersions = @()
+
           foreach ($version in $versions) {
             Write-Host "========================================" -ForegroundColor Cyan
             Write-Host "Building docs for $version" -ForegroundColor Cyan
@@ -94,6 +96,7 @@ jobs:
             git worktree add $workDir $version
             if ($LASTEXITCODE -ne 0) {
               Write-Warning "⚠️  Failed to create worktree for $version – skipping."
+              $failedVersions += $version
               continue
             }
 
@@ -141,6 +144,7 @@ jobs:
                 Write-Host "✅ Docs built for $version" -ForegroundColor Green
               } else {
                 Write-Warning "⚠️  No _site output produced for $version."
+                $failedVersions += $version
               }
             } finally {
               Pop-Location
@@ -149,6 +153,12 @@ jobs:
                 Write-Warning "⚠️  git worktree remove failed for $version (exit $LASTEXITCODE): $removeOutput"
               }
             }
+          }
+
+          if ($failedVersions.Count -gt 0) {
+            Write-Warning "⚠️  Failed to build docs for: $($failedVersions -join ', ')"
+            Write-Error "❌ $($failedVersions.Count) version(s) failed — aborting to avoid deploying incomplete docs."
+            exit 1
           }
 
           # Build 'latest' from the most recent stable v*.*.* tag so that the
@@ -285,9 +295,17 @@ jobs:
             Sort-Object -Property Major, Minor, Patch, Stable -Descending |
             Select-Object -ExpandProperty Tag
 
-          [array]$versions = @([PSCustomObject]@{ version = 'latest'; url = "${base}versions/latest/" })
+          # Derive versions list from actually built output directories (not all tags)
+          # to avoid linking to versions that failed to build
+          $builtDirs = Get-ChildItem -Path (Join-Path $outDir 'versions') -Directory | Select-Object -ExpandProperty Name
+          [array]$versions = @()
+          if ($builtDirs -contains 'latest') {
+            $versions += [PSCustomObject]@{ version = 'latest'; url = "${base}versions/latest/" }
+          }
           foreach ($t in $orderedTags) {
-            $versions += [PSCustomObject]@{ version = $t; url = "${base}versions/$t/" }
+            if ($builtDirs -contains $t) {
+              $versions += [PSCustomObject]@{ version = $t; url = "${base}versions/$t/" }
+            }
           }
 
           $versionsJson = ConvertTo-Json -InputObject $versions -Depth 3


### PR DESCRIPTION
## Summary
- Add build-all-versions.yaml workflow for building DocFX documentation for all tagged versions
- Triggered manually via workflow_dispatch
- Discovers versions automatically from git v*.*.* tags

## Test plan
- [ ] Run workflow manually from Actions tab after creating a version tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)