### PR TITLE
Sync release.yaml with repo-template

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -469,6 +469,34 @@ jobs:
             Pop-Location
           }
 
+      - name: Generate SBOM (CycloneDX)
+        if: steps.check-packages.outputs.has-packages == 'true'
+        shell: pwsh
+        run: |
+          dotnet tool install --global CycloneDX
+
+          $sbomDir = Join-Path $PWD 'nuget-packages'
+          $srcProjects = Get-ChildItem -Path 'src' -Filter '*.csproj' -Recurse -ErrorAction SilentlyContinue
+
+          if ($srcProjects.Count -eq 0) {
+            Write-Warning "No projects found in src/ - skipping SBOM generation"
+            return
+          }
+
+          foreach ($proj in $srcProjects) {
+            $sbomName = "$($proj.BaseName).bom.json"
+            $sbomPath = Join-Path $sbomDir $sbomName
+
+            Write-Host "📋 Generating SBOM for $($proj.Name)" -ForegroundColor Cyan
+            dotnet CycloneDX $proj.FullName --output $sbomDir --filename $sbomName --json
+
+            if ($LASTEXITCODE -ne 0) {
+              Write-Warning "⚠️ SBOM generation failed for $($proj.Name) - continuing"
+            } else {
+              Write-Host "✅ SBOM generated: $sbomName" -ForegroundColor Green
+            }
+          }
+
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v4
         with:
@@ -588,5 +616,7 @@ jobs:
           tag_name: ${{ github.event.release.tag_name }}
           files: |
             ./nuget-packages/*.nupkg
+            ./nuget-packages/*.bom.json
             release-coverage.zip
+
 


### PR DESCRIPTION
## Summary
- Add CycloneDX SBOM generation step after NuGet packaging
- Include `*.bom.json` files in GitHub Release assets

## Test plan
- [ ] Verify YAML parses cleanly
- [ ] Confirm SBOM step is positioned before Upload NuGet packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)