### PR TITLE
Fix test discovery and pin net5.0 Test SDK

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -253,7 +253,7 @@ jobs:
         run: |
           # Find all test projects (C#, VB.NET, F#)
           # Search both ./tests and root-level *.Tests.* directories for backwards compat
-          mapfile -d '' -t test_projects < <(find . -maxdepth 1 -type d -name "*.Tests.*" -print0 -o -type d -name "tests" -print0 | xargs -0 -I{} find {} -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
+          mapfile -d '' -t test_projects < <(find . -maxdepth 1 -type d -name "*.Tests.*" -print0 -o -type d -name "tests" -print0 | xargs -0 -r -I{} find {} -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
 
           if [ ${#test_projects[@]} -eq 0 ]; then
             echo "❌ No test projects found!"
@@ -801,7 +801,7 @@ jobs:
           test_projects=()
           while IFS= read -r -d '' file; do
           test_projects+=("$file")
-          done < <(find . -maxdepth 1 -type d -name "*.Tests.*" -print0 -o -type d -name "tests" -print0 | xargs -0 -I{} find {} -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
+          done < <(find . -maxdepth 1 -type d -name "*.Tests.*" -print0 -o -type d -name "tests" -print0 | xargs -0 -r -I{} find {} -type f \( -name "*.csproj" -o -name "*.vbproj" -o -name "*.fsproj" \) -print0)
 
           if [ ${#test_projects[@]} -eq 0 ]; then
             echo "❌ No test projects found!"


### PR DESCRIPTION
## Summary
- **Test discovery**: `pr.yaml` uses `pull_request_target` (runs from main), but hardcoded `find ./tests` while main's test project lives at root-level `Wolfgang.Extensions.Icollection.Tests.Unit/`. Now searches both `./tests` and root-level `*.Tests.*` directories.
- **net5.0 Test SDK**: Pin `Microsoft.NET.Test.Sdk` to `17.13.0` for `net5.0` only (18.x dropped support). Addresses Copilot review on #40 — avoids global `SuppressTfmSupportBuildErrors` that would mask real incompatibilities.

## Test plan
- [ ] Verify Stage 1 Linux Tests discover and run the test project
- [ ] Verify Stage 2 Windows Tests discover and run the test project
- [ ] Verify Stage 3 macOS Tests discover and run the test project

🤖 Generated with [Claude Code](https://claude.com/claude-code)