### PR TITLE
Move analyzer PackageReferences to individual csproj files

### DIFF
--- a/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
+++ b/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
@@ -34,5 +34,31 @@
 	  </None>
 	</ItemGroup>
 
+	<ItemGroup>
+		<PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="AsyncFixer" Version="2.1.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Meziantou.Analyzer" Version="3.0.44">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="10.22.0.136894">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Adds the 6 analyzer PackageReferences (Roslynator.Analyzers, AsyncFixer, Microsoft.VisualStudio.Threading.Analyzers, Microsoft.CodeAnalysis.BannedApiAnalyzers, Meziantou.Analyzer, SonarAnalyzer.CSharp) directly to each csproj file
- Each project now owns its analyzer references, eliminating the need to disable branch ruleset protection when updating versions via Dependabot

## Dependencies
- **Must merge #55 first** (Remove analyzer PackageReferences from Directory.Build.props) to avoid duplicate analyzer references

## Test plan
- [ ] Merge #55 first, then merge this PR
- [ ] Verify build succeeds with analyzers restored at the project level
- [ ] Confirm analyzer versions match what was previously in Directory.Build.props

🤖 Generated with [Claude Code](https://claude.com/claude-code)