### PR TITLE
Include README.md in NuGet package

### DIFF
--- a/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
+++ b/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
@@ -32,6 +32,10 @@
 	    <Pack>True</Pack>
 	    <PackagePath>\</PackagePath>
 	  </None>
+	  <None Include="..\..\README.md">
+	    <Pack>True</Pack>
+	    <PackagePath>\</PackagePath>
+	  </None>
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
Adds `<None Include="..\..\README.md" Pack="True" PackagePath="\">` to the source csproj so `README.md` is actually packaged.

## Why
The csproj declared `<PackageReadmeFile>README.md</PackageReadmeFile>` but never included `README.md` in the package contents. `dotnet pack` failed with:

```
error NU5039: The readme file 'README.md' does not exist in the package.
```

This is a drift from the canonical pattern used by sibling repos (IEnumerable-Extensions, IComparable-Extensions, etc.) which all include README.md the same way.

## Test plan
- [x] Verified locally: `dotnet pack` succeeds without `-p:PackageReadmeFile=` workaround