### PR TITLE
Sync .gitignore .gitleaks.toml from canonical

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -431,8 +431,3 @@ nuget-packages/
 docfx_project/_site/
 docfx_project/obj/
 
-# Generated documentation (built by CI/CD)
-docs/*
-!docs/.gitkeep
-!docs/RELEASE-WORKFLOW-SETUP.md
-!docs/README-FORMATTING.md


### PR DESCRIPTION
## Summary
Syncs `.gitignore` and (if applicable) `.gitleaks.toml` to canonical (`repo-template/main`).

These are protected configuration files. The PR workflow will fail by design on the protected-files guard. Requires admin merge after verifying the diff matches canonical byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)