### PR TITLE
D2: seed CHANGELOG with v0.2.0 entry (closes #98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [0.2.0] - 2026-05-01
+
+Initial public NuGet release.
+
+### Added
+
+- `AddRange<T>(this ICollection<T>, IEnumerable<T>)` extension method.
+  Pre-allocates capacity when the source is also `IList<T>` and the
+  appended sequence exposes `ICollection<T>.Count`, eliminating
+  intermediate resize allocations in the common batch-append path.
+- `IsEmpty<T>(this ICollection<T>)` and `IsNotEmpty<T>(this ICollection<T>)`
+  extension methods returning a Boolean for the source's empty state.
+- Multi-framework targeting: `net462`, `netstandard2.0`,
+  `netstandard2.1`, `net8.0`, `net10.0`.
+- README content packaged into the NuGet `.nupkg` so it renders on the
+  package's nuget.org page.
+
+[Unreleased]: https://github.com/Chris-Wolfgang/ICollection-Extensions/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/Chris-Wolfgang/ICollection-Extensions/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Initial public NuGet release.
 ### Added
 
 - `AddRange<T>(this ICollection<T>, IEnumerable<T>)` extension method.
-  Pre-allocates capacity when the source is also `IList<T>` and the
+  Pre-allocates capacity when the source is `List<T>` and the
   appended sequence exposes `ICollection<T>.Count`, eliminating
   intermediate resize allocations in the common batch-append path.
 - `IsEmpty<T>(this ICollection<T>)` and `IsNotEmpty<T>(this ICollection<T>)`


### PR DESCRIPTION
## Summary

Closes #98.

Adds a `## [0.2.0]` section to CHANGELOG.md documenting the
`AddRange` / `IsEmpty` / `IsNotEmpty` surface that shipped in the
initial public release, plus the compare-link footer.

The `[Unreleased]` section stays empty — its entries are populated
during the next release bump (alongside the canonical CI/metadata work
already on vNext).