### PR TITLE
P1: scaffold BenchmarkDotNet baseline project (closes #92)

### DIFF
--- a/ICollection-Extensions.slnx
+++ b/ICollection-Extensions.slnx
@@ -35,7 +35,9 @@
   <Folder Name="/.root/scripts/">
     <File Path="scripts/format.ps1" />
   </Folder>
-  <Folder Name="/benchmarks/" />
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj" />
+  </Folder>
   <Folder Name="/examples/" />
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj" />

--- a/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/ICollectionExtensionsBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/ICollectionExtensionsBenchmarks.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Wolfgang.Extensions.ICollection;
+
+namespace Wolfgang.Extensions.ICollection.Benchmarks;
+
+/// <summary>
+/// Microbenchmarks for the public extension methods. <c>AddRange</c> has
+/// two interesting shapes — the fast path where the source is also an
+/// <c>IList&lt;T&gt;</c> and the appended sequence exposes
+/// <c>ICollection&lt;T&gt;.Count</c> (capacity can be pre-allocated), and
+/// the slow path where neither holds (one-by-one append). The
+/// MemoryDiagnoser is enabled so any future refactor that introduces
+/// allocation surfaces in the gh-pages benchmark chart immediately.
+/// </summary>
+[MemoryDiagnoser]
+public class ICollectionExtensionsBenchmarks
+{
+    // 1024 items is enough to exercise the pre-allocation path's win over
+    // repeated resize on the slow path while staying well under 1 ms per
+    // op so the BDN ShortRun finishes quickly.
+    private const int Count = 1024;
+
+    private readonly int[] _itemsToAdd = new int[Count];
+
+
+
+    [Benchmark]
+    public List<int> AddRange_to_List_from_IList()
+    {
+        // Fast path: both sides expose Count + IList semantics.
+        var target = new List<int>();
+        target.AddRange((IEnumerable<int>)_itemsToAdd);
+        return target;
+    }
+
+
+
+    [Benchmark]
+    public LinkedList<int> AddRange_to_LinkedList_from_IList()
+    {
+        // Slow path: LinkedList is ICollection<T> but not IList<T>, so the
+        // capacity pre-allocation branch does not apply.
+        var target = new LinkedList<int>();
+        target.AddRange((IEnumerable<int>)_itemsToAdd);
+        return target;
+    }
+
+
+
+    [Benchmark]
+    public bool IsEmpty_on_empty_List() => new List<int>().IsEmpty();
+
+
+
+    [Benchmark]
+    public bool IsEmpty_on_nonempty_List() => _itemsToAdd.AsCollection().IsEmpty();
+
+
+
+    [Benchmark]
+    public bool IsNotEmpty_on_empty_List() => new List<int>().IsNotEmpty();
+
+
+
+    [Benchmark]
+    public bool IsNotEmpty_on_nonempty_List() => _itemsToAdd.AsCollection().IsNotEmpty();
+}
+
+
+
+/// <summary>
+/// Small helper to coerce an array into the <see cref="ICollection{T}"/>
+/// shape the extension methods take without allocating a new list.
+/// </summary>
+internal static class CollectionShim
+{
+    public static ICollection<T> AsCollection<T>(this T[] source) => source;
+}

--- a/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/ICollectionExtensionsBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/ICollectionExtensionsBenchmarks.cs
@@ -6,10 +6,14 @@ namespace Wolfgang.Extensions.ICollection.Benchmarks;
 
 /// <summary>
 /// Microbenchmarks for the public extension methods. <c>AddRange</c> has
-/// two interesting shapes — the fast path where the source is also an
-/// <c>IList&lt;T&gt;</c> and the appended sequence exposes
+/// two interesting shapes — the fast path where the target is
+/// <c>List&lt;T&gt;</c> and the appended sequence exposes
 /// <c>ICollection&lt;T&gt;.Count</c> (capacity can be pre-allocated), and
-/// the slow path where neither holds (one-by-one append). The
+/// the slow path where the target is some other <c>ICollection&lt;T&gt;</c>
+/// (one-by-one append, no pre-allocation). Every receiver is typed as
+/// <c>ICollection&lt;T&gt;</c> at the call site so the extension method
+/// wins overload resolution against any concrete-type instance method
+/// (e.g. <c>List&lt;T&gt;.AddRange</c> would otherwise bind first). The
 /// MemoryDiagnoser is enabled so any future refactor that introduces
 /// allocation surfaces in the gh-pages benchmark chart immediately.
 /// </summary>
@@ -26,45 +30,59 @@ public class ICollectionExtensionsBenchmarks
 
 
     [Benchmark]
-    public List<int> AddRange_to_List_from_IList()
+    public ICollection<int> AddRange_fast_path_List_target()
     {
-        // Fast path: both sides expose Count + IList semantics.
-        var target = new List<int>();
-        target.AddRange((IEnumerable<int>)_itemsToAdd);
+        // Fast path: target is List<T> (the only ICollection<T> with
+        // settable Capacity) AND _itemsToAdd is an int[], so the
+        // 'items is ICollection<T>' check succeeds and the pre-allocation
+        // branch fires. The receiver is typed as ICollection<T> so the
+        // extension wins overload resolution — without this typing,
+        // 'target.AddRange(...)' would bind to List<T>.AddRange instead.
+        ICollection<int> target = new List<int>();
+        target.AddRange(_itemsToAdd);
         return target;
     }
 
 
 
     [Benchmark]
-    public LinkedList<int> AddRange_to_LinkedList_from_IList()
+    public ICollection<int> AddRange_slow_path_LinkedList_target()
     {
-        // Slow path: LinkedList is ICollection<T> but not IList<T>, so the
-        // capacity pre-allocation branch does not apply.
-        var target = new LinkedList<int>();
-        target.AddRange((IEnumerable<int>)_itemsToAdd);
+        // Slow path: LinkedList<T> is ICollection<T> but not List<T>, so
+        // the capacity pre-allocation branch does not fire. Iteration
+        // falls through to one-by-one Add().
+        ICollection<int> target = new LinkedList<int>();
+        target.AddRange(_itemsToAdd);
         return target;
     }
 
 
 
     [Benchmark]
-    public bool IsEmpty_on_empty_List() => new List<int>().IsEmpty();
+    public bool IsEmpty_on_empty_collection()
+    {
+        ICollection<int> source = new List<int>();
+        return source.IsEmpty();
+    }
 
 
 
     [Benchmark]
-    public bool IsEmpty_on_nonempty_List() => _itemsToAdd.AsCollection().IsEmpty();
+    public bool IsEmpty_on_nonempty_collection() => _itemsToAdd.AsCollection().IsEmpty();
 
 
 
     [Benchmark]
-    public bool IsNotEmpty_on_empty_List() => new List<int>().IsNotEmpty();
+    public bool IsNotEmpty_on_empty_collection()
+    {
+        ICollection<int> source = new List<int>();
+        return source.IsNotEmpty();
+    }
 
 
 
     [Benchmark]
-    public bool IsNotEmpty_on_nonempty_List() => _itemsToAdd.AsCollection().IsNotEmpty();
+    public bool IsNotEmpty_on_nonempty_collection() => _itemsToAdd.AsCollection().IsNotEmpty();
 }
 
 

--- a/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Program.cs
+++ b/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.ICollection\Wolfgang.Extensions.ICollection.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+</Project>


### PR DESCRIPTION
## Summary

Closes #92.

Adds a `benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/`
project targeting `net10.0` with BenchmarkDotNet 0.15.8 + the
standard `BenchmarkSwitcher` entry point used by every Wolfgang.*
library benchmark project.

## What it benchmarks

- **`AddRange` fast path** — `List<int>` + `int[]` (both expose
  `Count` + `IList<T>` semantics, so the pre-allocation branch is
  taken).
- **`AddRange` slow path** — `LinkedList<int>` + `int[]` (target is
  `ICollection<T>` but not `IList<T>`, so capacity pre-allocation
  doesn't apply).
- **`IsEmpty` / `IsNotEmpty`** on empty + non-empty inputs.

`MemoryDiagnoser` is enabled so any regression that introduces a heap
allocation surfaces in the gh-pages chart produced by P2's
`benchmarks.yaml` workflow.

## Stacking

This PR bases on `feature/d2-changelog-seed` (PR #121). After #121
merges, GitHub will auto-promote this PR's base to `vNext`.