### PR TITLE
T4: tighten test quality — Theory split + capacity-path coverage

### DIFF
--- a/tests/Wolfgang.Extensions.ICollection.Tests.Unit/ICollectionExtensionTests.cs
+++ b/tests/Wolfgang.Extensions.ICollection.Tests.Unit/ICollectionExtensionTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.ObjectModel;
+
 namespace Wolfgang.Extensions.ICollection.Tests.Unit;
 
 // ReSharper disable once InconsistentNaming
@@ -315,16 +317,30 @@ public class ICollectionExtensionTests
 
 
 
-    [Fact]
-    public void IsEmpty_when_source_is_HashSet_returns_correct_result()
-    {
-        // Arrange
-        ICollection<int> empty = new HashSet<int>();
-        ICollection<int> nonEmpty = new HashSet<int> { 1, 2, 3 };
+    public static TheoryData<ICollection<int>, bool> IsEmpty_collection_type_cases =>
+        new()
+        {
+            { new List<int>(),                  true  },
+            { new List<int> { 1, 2, 3 },        false },
+            { new HashSet<int>(),               true  },
+            { new HashSet<int> { 1, 2, 3 },     false },
+            { new LinkedList<int>(),            true  },
+            { LinkedListWith(1, 2, 3),          false },
+            { new Collection<int>(),            true  },
+            { new Collection<int> { 1, 2, 3 },  false },
+        };
 
-        // Act & Assert
-        Assert.True(empty.IsEmpty());
-        Assert.False(nonEmpty.IsEmpty());
+    [Theory]
+    [MemberData(nameof(IsEmpty_collection_type_cases))]
+    public void IsEmpty_when_source_is_any_ICollection_implementation_returns_correct_result(
+        ICollection<int> source,
+        bool expected)
+    {
+        // Act
+        var result = source.IsEmpty();
+
+        // Assert
+        Assert.Equal(expected, result);
     }
 
 
@@ -376,16 +392,89 @@ public class ICollectionExtensionTests
 
 
 
-    [Fact]
-    public void IsNotEmpty_when_source_is_LinkedList_returns_correct_result()
-    {
-        // Arrange
-        ICollection<int> empty = new LinkedList<int>();
-        ICollection<int> nonEmpty = new LinkedList<int>();
-        nonEmpty.Add(42);
+    public static TheoryData<ICollection<int>, bool> IsNotEmpty_collection_type_cases =>
+        new()
+        {
+            { new List<int>(),                  false },
+            { new List<int> { 1, 2, 3 },        true  },
+            { new HashSet<int>(),               false },
+            { new HashSet<int> { 1, 2, 3 },     true  },
+            { new LinkedList<int>(),            false },
+            { LinkedListWith(1, 2, 3),          true  },
+            { new Collection<int>(),            false },
+            { new Collection<int> { 1, 2, 3 },  true  },
+        };
 
-        // Act & Assert
-        Assert.False(empty.IsNotEmpty());
-        Assert.True(nonEmpty.IsNotEmpty());
+    [Theory]
+    [MemberData(nameof(IsNotEmpty_collection_type_cases))]
+    public void IsNotEmpty_when_source_is_any_ICollection_implementation_returns_correct_result(
+        ICollection<int> source,
+        bool expected)
+    {
+        // Act
+        var result = source.IsNotEmpty();
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+
+
+    // =========================================================================
+    // Implementation-detail tests: capacity pre-allocation path
+    // =========================================================================
+
+    [Fact]
+    public void AddRange_when_source_is_List_and_items_is_ICollection_pre_allocates_capacity()
+    {
+        // Arrange — start with a list whose Capacity is less than the final
+        // Count so we can prove the extension grew it in one step rather than
+        // relying on List's amortised doubling.
+        var source = new List<int>(capacity: 1) { 0 };
+        var items = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+        // Act
+        source.AddRange(items);
+
+        // Assert — Capacity must accommodate the final count (10) exactly,
+        // proving the pre-allocation branch ran. If the optimisation regressed
+        // and List had to grow via Add()'s amortised doubling, Capacity would
+        // overshoot to 16 (or another power-of-two).
+        Assert.Equal(10, source.Capacity);
+        Assert.Equal(10, source.Count);
+    }
+
+
+
+    [Fact]
+    public void AddRange_when_source_List_already_has_sufficient_capacity_does_not_shrink_it()
+    {
+        // Arrange — list with deliberately oversized capacity.
+        var source = new List<int>(capacity: 100) { 0 };
+        var items = new List<int> { 1, 2, 3 };
+
+        // Act
+        source.AddRange(items);
+
+        // Assert — Capacity should NOT be reduced to fit; the
+        // Math.Max(current, needed) guard preserves over-allocations.
+        Assert.Equal(100, source.Capacity);
+        Assert.Equal(4, source.Count);
+    }
+
+
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private static LinkedList<T> LinkedListWith<T>(params T[] items)
+    {
+        var list = new LinkedList<T>();
+        foreach (var item in items)
+        {
+            list.AddLast(item);
+        }
+        return list;
     }
 }


### PR DESCRIPTION
## Summary

Closes #117 (Audit test quality — T4 canonical initiative).

## Findings addressed

### 1. Combined-scenario Facts split into Theory + per-type cases

`IsEmpty_when_source_is_HashSet_returns_correct_result` and
`IsNotEmpty_when_source_is_LinkedList_returns_correct_result` each
exercised two scenarios in a single `[Fact]` — refactored into
`[Theory]` methods backed by `TheoryData` covering `List<T>`,
`HashSet<T>`, `LinkedList<T>`, and `Collection<T>` empty + non-empty
pairs (8 cases per Theory). Failures now report per-scenario instead
of hiding behind a combined assert.

### 2. Capacity-pre-allocation path coverage

`AddRange`'s `List<T> + ICollection<T>` capacity optimisation
(`ICollectionExtensions.cs` lines 86-89) had no test coverage. Added
two `[Fact]`s:

- `AddRange_when_source_is_List_and_items_is_ICollection_pre_allocates_capacity`
  proves Capacity is set to the exact final count rather than
  overshooting via List's amortised doubling.
- `AddRange_when_source_List_already_has_sufficient_capacity_does_not_shrink_it`
  proves the `Math.Max(current, needed)` guard preserves
  over-allocations.

### 3. LinkedListWith helper

Added a private `LinkedListWith<T>(params)` helper since
`LinkedList<T>`'s collection-initialiser support varies by TFM.

## Test count

23 → 39 (16 Theory cases + 2 capacity Facts).

## T4 audit findings deferred / not actioned

- Raw `Assert.True(result)` / `Assert.False(result)` on bool-returning
  methods: not changed. xunit has no stronger matcher for a raw bool
  return; the assertion is already idiomatic.
- "Not thread-safe" doc claim is not exercised by a concurrency test:
  defensive doc only; not worth a flaky concurrency test in a public
  extension method whose synchronisation responsibility is documented
  as the caller's.