### PR TITLE
C5: quick-wins from code-review (5 trivial findings)

### DIFF
--- a/ICollection-Extensions.slnx
+++ b/ICollection-Extensions.slnx
@@ -20,7 +20,7 @@
   </Folder>
   <Folder Name="/.root/.github/workflows/">
     <File Path=".github/workflows/build-all-versions.yaml" />
-    <File Path=".github/workflows/codeql.yml" />
+    <File Path=".github/workflows/codeql.yaml" />
     <File Path=".github/workflows/docfx.yaml" />
     <File Path=".github/workflows/pr.yaml" />
     <File Path=".github/workflows/release.yaml" />

--- a/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
+++ b/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 
 namespace Wolfgang.Extensions.ICollection;
 
-// ReSharper disable once InconsistentNaming
+
 /// <summary>
-/// A collection of extension methods to <see cref="ICollection{T}"/>
+/// A collection of extension methods to <see cref="ICollection{T}"/>.
 /// </summary>
 public static class ICollectionExtensions
 {
@@ -81,8 +81,10 @@ public static class ICollectionExtensions
             throw new ArgumentNullException(nameof(items));
         }
 
-        // If items is a collection, we know the count upfront and can try to
-        // pre-allocate capacity on the target to avoid repeated resizing.
+        // Pre-allocate capacity on the target when it's a List<T> (the only
+        // ICollection<T> with a settable Capacity) and items exposes Count
+        // up-front via ICollection<T>. Both conditions must hold; without
+        // them the loop below just relies on the target's own growth policy.
         if (items is ICollection<T> itemsCollection && source is List<T> list)
         {
             list.Capacity = Math.Max(list.Capacity, list.Count + itemsCollection.Count);

--- a/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
+++ b/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
@@ -13,6 +13,7 @@
 		<Title>$(AssemblyName)</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A collection of extension methods for types that implement ICollection&lt;T&gt;</Description>
+		<PackageTags>icollection;collection;extensions;extension-methods;addrange;dotnet;netstandard</PackageTags>
 		<Copyright>Copyright 2026 Chris Wolfgang</Copyright>
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/ICollection-Extensions</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Chris-Wolfgang/ICollection-Extensions.git</RepositoryUrl>

--- a/tests/Wolfgang.Extensions.ICollection.Tests.Unit/Wolfgang.Extensions.ICollection.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.ICollection.Tests.Unit/Wolfgang.Extensions.ICollection.Tests.Unit.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFrameworks>net462;net47;net471;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
         <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-        <Version>1.0.0</Version>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Summary

Five trivial-effort findings from the `/code-review` pass on
ICollection-Extensions, batched into one PR.

| # | Finding | File |
|---|---|---|
| 1 | `.slnx` referenced `codeql.yml`, actual file is `codeql.yaml` | `ICollection-Extensions.slnx` |
| 2 | Missing `<PackageTags>` (canonical CI3 expectation) | `src/.../*.csproj` |
| 3 | Stale `<Version>1.0.0</Version>` on test csproj — unused, dropped | `tests/.../*.csproj` |
| 4 | Stale `// ReSharper disable once InconsistentNaming` directive | `src/.../ICollectionExtensions.cs` |
| 5 | Vague pre-allocation inline comment didn't mention both required conditions | `src/.../ICollectionExtensions.cs` |

Build: 0 Warnings, 0 Errors locally. Closes #87 (version metadata
consistency), partial #91 (dead-code stragglers).

## Findings deferred to separate PRs

- **`IsEmpty`/`IsNotEmpty` `[Fact]` → `[Theory]` conversion** (Phase 4.5)
  — there's already a stashed WIP for this; will land as the T4
  test-quality PR (#117).
- **`.github/copilot-instructions.md` rewrite** (Phase 6) — currently
  168 lines of unchanged repo-template content. Needs a repo-specific
  rewrite (separate PR).

## Stacking

Bases on `feature/d-readme-audit` (PR #124). Top of the vNext stack
right now.