### PR TITLE
benchmarks: add curated .editorconfig (closes #114)

### DIFF
--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -1,0 +1,30 @@
+# Benchmark-project EditorConfig override.
+#
+# Benchmarks intentionally do things that production code shouldn't:
+#   - public no-op methods returning values that are immediately discarded
+#     (the whole point — BenchmarkDotNet's [Benchmark] attribute requires
+#     public methods so it can JIT them as separate callable wrappers)
+#   - allocations measured as expected output, not regressions
+#   - constants chosen to bias toward slow / fast paths rather than
+#     reflecting realistic input
+#
+# Rules from the root .editorconfig and Directory.Build.props
+# (TreatWarningsAsErrors=true in Release) still apply; this file just
+# relaxes the analyzer rules that the BDN attribute model would otherwise
+# trip.
+root = false
+
+[*.cs]
+
+# Roslynator: "Mark members as static" — BenchmarkDotNet's [Benchmark]
+# methods are instance-level by design.
+dotnet_diagnostic.RCS1213.severity = none
+dotnet_diagnostic.CA1822.severity = none
+
+# Meziantou: "Use a return type with the value type Span<T>" — benchmark
+# return values are sinks, not actual outputs callers depend on.
+dotnet_diagnostic.MA0089.severity = none
+
+# Sonar: "Methods should not have identical implementations" — common
+# in *_fast / *_slow path comparison benchmarks.
+dotnet_diagnostic.S4144.severity = none


### PR DESCRIPTION
## Summary

Closes #114.

Pins the benchmark project to `TreatWarningsAsErrors` (already on
fleet-wide via `Directory.Build.props` in Release) while selectively
quieting the analyzer rules that BenchmarkDotNet's instance-public-
method convention would otherwise trip.

## Rules relaxed (with rationale)

| Rule | Rationale |
|---|---|
| `RCS1213` / `CA1822` (mark members as static) | `[Benchmark]` methods are instance-level by design — BDN JITs them as separate callables. |
| `MA0089` (Span<T> return type) | Benchmark return values are sinks for the JIT, not actual outputs callers depend on. |
| `S4144` (identical implementations) | Fast/slow-path comparison benchmarks legitimately have near-identical bodies. |

Local build: 0 warnings, 0 errors with TWE active.