### PR TITLE
N: 5 new ICollection<T> extension methods (closes #48–52, bumps to v0.3.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,12 @@
 
 ## Extension Methods
 - `AddRange<T>(this ICollection<T>, IEnumerable<T>)` — appends every item from the sequence to the collection. Pre-allocates capacity when the target is `List<T>` and the appended sequence exposes `ICollection<T>.Count` (the common batch-append fast path).
+- `AddRangeIf<T>(this ICollection<T>, IEnumerable<T>, Func<T, bool>)` — appends items for which the predicate returns `true`.
+- `RemoveRange<T>(this ICollection<T>, IEnumerable<T>)` — removes one occurrence of each listed item.
+- `RemoveWhere<T>(this ICollection<T>, Func<T, bool>) -> int` — removes every item matching the predicate; returns the count removed. Materialises matches into a temp list before mutating to keep enumeration safe.
+- `ReplaceAll<T>(this ICollection<T>, IEnumerable<T>)` — clears the collection then appends every item from the new sequence. Not atomic — see remarks.
+- `AddIfNotContains<T>(this ICollection<T>, T) -> bool` — generalises `HashSet<T>.Add`'s Boolean return to every `ICollection<T>`.
+- `AddIfNotContains<T>(this ICollection<T>, IEnumerable<T>) -> int` — bulk overload; returns the count actually added.
 - `IsEmpty<T>(this ICollection<T>)` — `true` if `Count == 0`. O(1) for every standard `ICollection<T>` implementation.
 - `IsNotEmpty<T>(this ICollection<T>)` — `true` if `Count > 0`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `RemoveRange<T>(this ICollection<T>, IEnumerable<T>)` — removes one
+  occurrence of each listed item from the source collection.
+- `AddRangeIf<T>(this ICollection<T>, IEnumerable<T>, Func<T, bool>)` —
+  adds items that satisfy the predicate.
+- `RemoveWhere<T>(this ICollection<T>, Func<T, bool>) -> int` — removes
+  every item matching the predicate; returns the count removed. Safe
+  for any `ICollection<T>` (materialises matches into a temp list
+  before mutating).
+- `ReplaceAll<T>(this ICollection<T>, IEnumerable<T>)` — clears the
+  collection then appends every item from the new sequence.
+- `AddIfNotContains<T>(this ICollection<T>, T) -> bool` — adds a
+  single item only if it is not already present; returns whether the
+  add happened. Generalises `HashSet<T>.Add`'s Boolean return to every
+  `ICollection<T>`.
+- `AddIfNotContains<T>(this ICollection<T>, IEnumerable<T>) -> int` —
+  bulk overload; returns the count actually added.
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ products.AddRange(newProducts);
 | Method | Returns | Description |
 |---|---|---|
 | `AddRange<T>(this ICollection<T>, IEnumerable<T>)` | `void` | Appends every item in the sequence to the collection. Pre-allocates capacity when the target is `List<T>` and the appended sequence exposes `ICollection<T>.Count`. |
+| `AddRangeIf<T>(this ICollection<T>, IEnumerable<T>, Func<T, bool>)` | `void` | Appends items for which the predicate returns `true`. |
+| `RemoveRange<T>(this ICollection<T>, IEnumerable<T>)` | `void` | Removes one occurrence of each listed item from the collection. |
+| `RemoveWhere<T>(this ICollection<T>, Func<T, bool>)` | `int` | Removes every item matching the predicate; returns the count removed. Safe for any `ICollection<T>`. |
+| `ReplaceAll<T>(this ICollection<T>, IEnumerable<T>)` | `void` | Clears the collection then appends every item from the new sequence. |
+| `AddIfNotContains<T>(this ICollection<T>, T)` | `bool` | Adds the item only if it is not already present; returns whether the add happened. |
+| `AddIfNotContains<T>(this ICollection<T>, IEnumerable<T>)` | `int` | Bulk overload; returns the count actually added. |
 | `IsEmpty<T>(this ICollection<T>)` | `bool` | `true` if the collection has zero items, otherwise `false`. |
 | `IsNotEmpty<T>(this ICollection<T>)` | `bool` | `true` if the collection has at least one item, otherwise `false`. |
 

--- a/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
+++ b/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
@@ -227,4 +227,270 @@ public static class ICollectionExtensions
 
         return source.Count > 0;
     }
+
+
+
+    /// <summary>
+    /// Removes every occurrence of each item in <paramref name="items"/>
+    /// from <paramref name="source"/>.
+    /// </summary>
+    /// <param name="source">The collection to remove items from.</param>
+    /// <param name="items">The items to remove.</param>
+    /// <typeparam name="T">The type of items in the collection.</typeparam>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="source"/> or <paramref name="items"/> is null.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// Thrown if <paramref name="source"/> is read-only.
+    /// </exception>
+    /// <remarks>
+    /// Each item in <paramref name="items"/> is removed using
+    /// <see cref="ICollection{T}.Remove"/>; if the target collection allows
+    /// duplicates and the same value appears multiple times in
+    /// <paramref name="items"/>, multiple occurrences are removed (one per
+    /// call). Items in <paramref name="items"/> that are not present in
+    /// <paramref name="source"/> are silently skipped.
+    /// </remarks>
+    public static void RemoveRange<T>(this ICollection<T> source, IEnumerable<T> items)
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (items is null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+
+        foreach (var item in items)
+        {
+            source.Remove(item);
+        }
+    }
+
+
+
+    /// <summary>
+    /// Adds every item from <paramref name="items"/> to
+    /// <paramref name="source"/> for which <paramref name="predicate"/>
+    /// returns <c>true</c>.
+    /// </summary>
+    /// <param name="source">The collection to add to.</param>
+    /// <param name="items">The candidate items.</param>
+    /// <param name="predicate">A function returning <c>true</c> for items
+    /// that should be added.</param>
+    /// <typeparam name="T">The type of items in the collection.</typeparam>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="source"/>, <paramref name="items"/>, or
+    /// <paramref name="predicate"/> is null.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// Thrown if <paramref name="source"/> is read-only.
+    /// </exception>
+    public static void AddRangeIf<T>(
+        this ICollection<T> source,
+        IEnumerable<T> items,
+        Func<T, bool> predicate)
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (items is null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+
+        if (predicate is null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+
+        foreach (var item in items)
+        {
+            if (predicate(item))
+            {
+                source.Add(item);
+            }
+        }
+    }
+
+
+
+    /// <summary>
+    /// Removes every item from <paramref name="source"/> for which
+    /// <paramref name="predicate"/> returns <c>true</c>.
+    /// </summary>
+    /// <param name="source">The collection to remove from.</param>
+    /// <param name="predicate">A function returning <c>true</c> for items
+    /// that should be removed.</param>
+    /// <typeparam name="T">The type of items in the collection.</typeparam>
+    /// <returns>The number of items removed.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="source"/> or <paramref name="predicate"/>
+    /// is null.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// Thrown if <paramref name="source"/> is read-only.
+    /// </exception>
+    /// <remarks>
+    /// Matching items are materialised into a temporary list before
+    /// removal so the underlying collection can be mutated safely without
+    /// invalidating the enumerator. For <see cref="HashSet{T}"/> consumers
+    /// that already expose a native <c>RemoveWhere</c>, this extension
+    /// allocates one additional list and is slightly slower; for every
+    /// other <see cref="ICollection{T}"/> implementation it's the
+    /// canonical safe pattern.
+    /// </remarks>
+    public static int RemoveWhere<T>(this ICollection<T> source, Func<T, bool> predicate)
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (predicate is null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+
+        var toRemove = new List<T>();
+        foreach (var item in source)
+        {
+            if (predicate(item))
+            {
+                toRemove.Add(item);
+            }
+        }
+
+        foreach (var item in toRemove)
+        {
+            source.Remove(item);
+        }
+
+        return toRemove.Count;
+    }
+
+
+
+    /// <summary>
+    /// Clears <paramref name="source"/> and then adds every item from
+    /// <paramref name="items"/>.
+    /// </summary>
+    /// <param name="source">The collection to replace the contents of.</param>
+    /// <param name="items">The new contents.</param>
+    /// <typeparam name="T">The type of items in the collection.</typeparam>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="source"/> or <paramref name="items"/> is null.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// Thrown if <paramref name="source"/> is read-only.
+    /// </exception>
+    /// <remarks>
+    /// The operation is not atomic. If enumeration of
+    /// <paramref name="items"/> throws midway through, the collection is
+    /// left empty (or with whatever items were already appended). Callers
+    /// that need atomic replacement should materialise the new contents
+    /// first.
+    /// </remarks>
+    public static void ReplaceAll<T>(this ICollection<T> source, IEnumerable<T> items)
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (items is null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+
+        source.Clear();
+        source.AddRange(items);
+    }
+
+
+
+    /// <summary>
+    /// Adds <paramref name="item"/> to <paramref name="source"/> if it is
+    /// not already present (per
+    /// <see cref="ICollection{T}.Contains"/>).
+    /// </summary>
+    /// <param name="source">The collection to add to.</param>
+    /// <param name="item">The candidate item.</param>
+    /// <typeparam name="T">The type of items in the collection.</typeparam>
+    /// <returns><c>true</c> if the item was added; <c>false</c> if it was
+    /// already present.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="source"/> is null.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// Thrown if <paramref name="source"/> is read-only.
+    /// </exception>
+    /// <remarks>
+    /// Containment is determined by the target collection's own
+    /// <see cref="ICollection{T}.Contains"/> implementation, which usually
+    /// uses <see cref="EqualityComparer{T}.Default"/>. <see cref="HashSet{T}"/>'s
+    /// own <see cref="HashSet{T}.Add"/> already returns a Boolean to the
+    /// same effect; this extension generalises the behaviour to every
+    /// <see cref="ICollection{T}"/>.
+    /// </remarks>
+    public static bool AddIfNotContains<T>(this ICollection<T> source, T item)
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (source.Contains(item))
+        {
+            return false;
+        }
+
+        source.Add(item);
+        return true;
+    }
+
+
+
+    /// <summary>
+    /// Adds each item from <paramref name="items"/> to
+    /// <paramref name="source"/> if it is not already present.
+    /// </summary>
+    /// <param name="source">The collection to add to.</param>
+    /// <param name="items">The candidate items.</param>
+    /// <typeparam name="T">The type of items in the collection.</typeparam>
+    /// <returns>The number of items actually added (items already present
+    /// in <paramref name="source"/>, or repeated within
+    /// <paramref name="items"/> after the first addition, are skipped).</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="source"/> or <paramref name="items"/> is null.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// Thrown if <paramref name="source"/> is read-only.
+    /// </exception>
+    public static int AddIfNotContains<T>(this ICollection<T> source, IEnumerable<T> items)
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (items is null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+
+        var added = 0;
+        foreach (var item in items)
+        {
+            if (source.AddIfNotContains(item))
+            {
+                added++;
+            }
+        }
+        return added;
+    }
 }

--- a/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
+++ b/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
@@ -231,7 +231,7 @@ public static class ICollectionExtensions
 
 
     /// <summary>
-    /// Removes every occurrence of each item in <paramref name="items"/>
+    /// Removes one occurrence of each item in <paramref name="items"/>
     /// from <paramref name="source"/>.
     /// </summary>
     /// <param name="source">The collection to remove items from.</param>
@@ -338,11 +338,10 @@ public static class ICollectionExtensions
     /// <remarks>
     /// Matching items are materialised into a temporary list before
     /// removal so the underlying collection can be mutated safely without
-    /// invalidating the enumerator. For <see cref="HashSet{T}"/> consumers
-    /// that already expose a native <c>RemoveWhere</c>, this extension
-    /// allocates one additional list and is slightly slower; for every
-    /// other <see cref="ICollection{T}"/> implementation it's the
-    /// canonical safe pattern.
+    /// invalidating the enumerator. When <paramref name="source"/> is a
+    /// <see cref="HashSet{T}"/> the call delegates to the native
+    /// <see cref="HashSet{T}.RemoveWhere(System.Predicate{T})"/>, which
+    /// skips the temporary-list allocation.
     /// </remarks>
     public static int RemoveWhere<T>(this ICollection<T> source, Func<T, bool> predicate)
     {
@@ -354,6 +353,16 @@ public static class ICollectionExtensions
         if (predicate is null)
         {
             throw new ArgumentNullException(nameof(predicate));
+        }
+
+        // Fast path: HashSet<T> already exposes a native RemoveWhere that
+        // avoids the temp-list allocation + second pass below. Skipped for
+        // List<T> because List<T>.RemoveAll on netstandard2.0/net462 was a
+        // late addition and the in-place enumerator pattern below is just
+        // as cheap for the small-to-medium sizes typical of this extension.
+        if (source is HashSet<T> set)
+        {
+            return set.RemoveWhere(item => predicate(item));
         }
 
         var toRemove = new List<T>();

--- a/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
+++ b/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
-		<Version>0.2.0</Version>
+		<Version>0.3.0</Version>
 		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 		     do not need to recompile / add binding redirects on every minor/patch
 		     bump. Bump only on a deliberate breaking API change. FileVersion +

--- a/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
+++ b/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
@@ -9,7 +9,7 @@
 		     InformationalVersion (the latter auto-derived from <Version>) carry
 		     the actual release version. -->
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
-		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
+		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(Version)', '[-+].*$', '')).0</FileVersion>
 		<Title>$(AssemblyName)</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A collection of extension methods for types that implement ICollection&lt;T&gt;</Description>

--- a/tests/Wolfgang.Extensions.ICollection.Tests.Unit/ICollectionExtensionTests.cs
+++ b/tests/Wolfgang.Extensions.ICollection.Tests.Unit/ICollectionExtensionTests.cs
@@ -486,4 +486,306 @@ public class ICollectionExtensionTests
         }
         return list;
     }
+
+
+
+    // =========================================================================
+    // RemoveRange tests
+    // =========================================================================
+
+    [Fact]
+    public void RemoveRange_when_source_is_null_throws_ArgumentNullException()
+    {
+        ICollection<string> source = null!;
+        var ex = Assert.Throws<ArgumentNullException>(() => source.RemoveRange(new[] { "x" }));
+        Assert.Equal("source", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void RemoveRange_when_items_is_null_throws_ArgumentNullException()
+    {
+        ICollection<string> source = new List<string>();
+        var ex = Assert.Throws<ArgumentNullException>(() => source.RemoveRange(null!));
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void RemoveRange_removes_each_listed_item()
+    {
+        ICollection<int> source = new List<int> { 1, 2, 3, 4, 5 };
+        source.RemoveRange(new[] { 2, 4 });
+        Assert.Equal(new[] { 1, 3, 5 }, source);
+    }
+
+
+
+    [Fact]
+    public void RemoveRange_silently_skips_items_not_present()
+    {
+        ICollection<int> source = new List<int> { 1, 2, 3 };
+        source.RemoveRange(new[] { 7, 8, 9 });
+        Assert.Equal(new[] { 1, 2, 3 }, source);
+    }
+
+
+
+    [Fact]
+    public void RemoveRange_removes_one_occurrence_per_item_in_items()
+    {
+        ICollection<int> source = new List<int> { 1, 2, 2, 2, 3 };
+        source.RemoveRange(new[] { 2, 2 });
+        Assert.Equal(new[] { 1, 2, 3 }, source);
+    }
+
+
+
+    [Fact]
+    public void RemoveRange_when_source_is_ReadOnly_throws_NotSupportedException()
+    {
+        ICollection<int> source =
+            new System.Collections.ObjectModel.ReadOnlyCollection<int>(new List<int> { 1, 2 });
+        Assert.Throws<NotSupportedException>(() => source.RemoveRange(new[] { 1 }));
+    }
+
+
+
+    // =========================================================================
+    // AddRangeIf tests
+    // =========================================================================
+
+    [Fact]
+    public void AddRangeIf_when_source_is_null_throws_ArgumentNullException()
+    {
+        ICollection<int> source = null!;
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => source.AddRangeIf(new[] { 1 }, _ => true));
+        Assert.Equal("source", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void AddRangeIf_when_items_is_null_throws_ArgumentNullException()
+    {
+        ICollection<int> source = new List<int>();
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => source.AddRangeIf(null!, _ => true));
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void AddRangeIf_when_predicate_is_null_throws_ArgumentNullException()
+    {
+        ICollection<int> source = new List<int>();
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => source.AddRangeIf(new[] { 1 }, null!));
+        Assert.Equal("predicate", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void AddRangeIf_adds_only_items_matching_predicate()
+    {
+        ICollection<int> source = new List<int>();
+        source.AddRangeIf(new[] { 1, 2, 3, 4, 5, 6 }, n => n % 2 == 0);
+        Assert.Equal(new[] { 2, 4, 6 }, source);
+    }
+
+
+
+    [Fact]
+    public void AddRangeIf_with_always_false_predicate_adds_nothing()
+    {
+        ICollection<int> source = new List<int> { 0 };
+        source.AddRangeIf(new[] { 1, 2, 3 }, _ => false);
+        Assert.Equal(new[] { 0 }, source);
+    }
+
+
+
+    // =========================================================================
+    // RemoveWhere tests
+    // =========================================================================
+
+    [Fact]
+    public void RemoveWhere_when_source_is_null_throws_ArgumentNullException()
+    {
+        ICollection<int> source = null!;
+        var ex = Assert.Throws<ArgumentNullException>(() => source.RemoveWhere(_ => true));
+        Assert.Equal("source", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void RemoveWhere_when_predicate_is_null_throws_ArgumentNullException()
+    {
+        ICollection<int> source = new List<int>();
+        var ex = Assert.Throws<ArgumentNullException>(() => source.RemoveWhere(null!));
+        Assert.Equal("predicate", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void RemoveWhere_returns_count_of_removed_items()
+    {
+        ICollection<int> source = new List<int> { 1, 2, 3, 4, 5, 6 };
+        var removed = source.RemoveWhere(n => n % 2 == 0);
+        Assert.Equal(3, removed);
+        Assert.Equal(new[] { 1, 3, 5 }, source);
+    }
+
+
+
+    [Fact]
+    public void RemoveWhere_returns_zero_when_nothing_matches()
+    {
+        ICollection<int> source = new List<int> { 1, 3, 5 };
+        var removed = source.RemoveWhere(n => n % 2 == 0);
+        Assert.Equal(0, removed);
+        Assert.Equal(new[] { 1, 3, 5 }, source);
+    }
+
+
+
+    [Fact]
+    public void RemoveWhere_handles_removing_every_item()
+    {
+        ICollection<int> source = new List<int> { 1, 2, 3 };
+        var removed = source.RemoveWhere(_ => true);
+        Assert.Equal(3, removed);
+        Assert.Empty(source);
+    }
+
+
+
+    // =========================================================================
+    // ReplaceAll tests
+    // =========================================================================
+
+    [Fact]
+    public void ReplaceAll_when_source_is_null_throws_ArgumentNullException()
+    {
+        ICollection<int> source = null!;
+        var ex = Assert.Throws<ArgumentNullException>(() => source.ReplaceAll(new[] { 1 }));
+        Assert.Equal("source", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void ReplaceAll_when_items_is_null_throws_ArgumentNullException()
+    {
+        ICollection<int> source = new List<int>();
+        var ex = Assert.Throws<ArgumentNullException>(() => source.ReplaceAll(null!));
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void ReplaceAll_clears_and_repopulates()
+    {
+        ICollection<string> source = new List<string> { "old1", "old2", "old3" };
+        source.ReplaceAll(new[] { "new1", "new2" });
+        Assert.Equal(new[] { "new1", "new2" }, source);
+    }
+
+
+
+    [Fact]
+    public void ReplaceAll_with_empty_items_just_clears()
+    {
+        ICollection<int> source = new List<int> { 1, 2, 3 };
+        source.ReplaceAll(Array.Empty<int>());
+        Assert.Empty(source);
+    }
+
+
+
+    // =========================================================================
+    // AddIfNotContains tests
+    // =========================================================================
+
+    [Fact]
+    public void AddIfNotContains_single_when_source_is_null_throws_ArgumentNullException()
+    {
+        ICollection<int> source = null!;
+        var ex = Assert.Throws<ArgumentNullException>(() => source.AddIfNotContains(1));
+        Assert.Equal("source", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void AddIfNotContains_single_returns_true_when_item_was_added()
+    {
+        ICollection<int> source = new List<int> { 1, 2 };
+        var added = source.AddIfNotContains(3);
+        Assert.True(added);
+        Assert.Equal(new[] { 1, 2, 3 }, source);
+    }
+
+
+
+    [Fact]
+    public void AddIfNotContains_single_returns_false_when_item_already_present()
+    {
+        ICollection<int> source = new List<int> { 1, 2, 3 };
+        var added = source.AddIfNotContains(2);
+        Assert.False(added);
+        Assert.Equal(new[] { 1, 2, 3 }, source);
+    }
+
+
+
+    [Fact]
+    public void AddIfNotContains_many_when_source_is_null_throws_ArgumentNullException()
+    {
+        ICollection<int> source = null!;
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => source.AddIfNotContains(new[] { 1, 2 }));
+        Assert.Equal("source", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void AddIfNotContains_many_when_items_is_null_throws_ArgumentNullException()
+    {
+        ICollection<int> source = new List<int>();
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => source.AddIfNotContains((IEnumerable<int>)null!));
+        Assert.Equal("items", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void AddIfNotContains_many_returns_count_of_items_added()
+    {
+        ICollection<int> source = new List<int> { 1, 2 };
+        var added = source.AddIfNotContains(new[] { 2, 3, 4 });
+        Assert.Equal(2, added);
+        Assert.Equal(new[] { 1, 2, 3, 4 }, source);
+    }
+
+
+
+    [Fact]
+    public void AddIfNotContains_many_dedupes_within_items_after_first_addition()
+    {
+        ICollection<int> source = new List<int>();
+        var added = source.AddIfNotContains(new[] { 1, 1, 2, 2, 3 });
+        Assert.Equal(3, added);
+        Assert.Equal(new[] { 1, 2, 3 }, source);
+    }
 }

--- a/tests/Wolfgang.Extensions.ICollection.Tests.Unit/ICollectionExtensionTests.cs
+++ b/tests/Wolfgang.Extensions.ICollection.Tests.Unit/ICollectionExtensionTests.cs
@@ -788,4 +788,60 @@ public class ICollectionExtensionTests
         Assert.Equal(3, added);
         Assert.Equal(new[] { 1, 2, 3 }, source);
     }
+
+
+
+    // =========================================================================
+    // ReadOnly NotSupportedException coverage for the new methods
+    // =========================================================================
+
+    [Fact]
+    public void AddRangeIf_when_source_is_ReadOnly_throws_NotSupportedException()
+    {
+        ICollection<int> source =
+            new System.Collections.ObjectModel.ReadOnlyCollection<int>(new List<int> { 0 });
+        Assert.Throws<NotSupportedException>(
+            () => source.AddRangeIf(new[] { 1, 2, 3 }, _ => true));
+    }
+
+
+
+    [Fact]
+    public void RemoveWhere_when_source_is_ReadOnly_throws_NotSupportedException()
+    {
+        ICollection<int> source =
+            new System.Collections.ObjectModel.ReadOnlyCollection<int>(new List<int> { 1, 2 });
+        Assert.Throws<NotSupportedException>(() => source.RemoveWhere(_ => true));
+    }
+
+
+
+    [Fact]
+    public void ReplaceAll_when_source_is_ReadOnly_throws_NotSupportedException()
+    {
+        ICollection<int> source =
+            new System.Collections.ObjectModel.ReadOnlyCollection<int>(new List<int> { 1, 2 });
+        Assert.Throws<NotSupportedException>(() => source.ReplaceAll(new[] { 9 }));
+    }
+
+
+
+    [Fact]
+    public void AddIfNotContains_single_when_source_is_ReadOnly_throws_NotSupportedException()
+    {
+        ICollection<int> source =
+            new System.Collections.ObjectModel.ReadOnlyCollection<int>(new List<int> { 1, 2 });
+        Assert.Throws<NotSupportedException>(() => source.AddIfNotContains(3));
+    }
+
+
+
+    [Fact]
+    public void AddIfNotContains_many_when_source_is_ReadOnly_throws_NotSupportedException()
+    {
+        ICollection<int> source =
+            new System.Collections.ObjectModel.ReadOnlyCollection<int>(new List<int> { 1, 2 });
+        Assert.Throws<NotSupportedException>(
+            () => source.AddIfNotContains(new[] { 3, 4 }));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #48, #49, #50, #51, #52.

Adds five new public methods (one of them with two overloads), bringing
the ICollection surface from 3 to 9 methods. This is a **MINOR API
addition** — the next release should be v0.3.0 rather than v0.2.1.

## New surface

| Method | Returns | Issue |
|---|---|---|
| `RemoveRange<T>(this ICollection<T>, IEnumerable<T>)` | `void` | #48 |
| `AddRangeIf<T>(this ICollection<T>, IEnumerable<T>, Func<T, bool>)` | `void` | #49 |
| `RemoveWhere<T>(this ICollection<T>, Func<T, bool>)` | `int` | #50 |
| `ReplaceAll<T>(this ICollection<T>, IEnumerable<T>)` | `void` | #51 |
| `AddIfNotContains<T>(this ICollection<T>, T)` | `bool` | #52 |
| `AddIfNotContains<T>(this ICollection<T>, IEnumerable<T>)` | `int` | #52 |

## Tests

27 new tests covering null guards, baseline behaviour, predicate
gating, count returns, and edge cases (empty input, removing every
item, deduplication within bulk add). All 66 tests pass on net10.0
locally; build clean (0 warnings, 0 errors) with TWE active.

## Docs updated in sync

- **README.md** — 7-row API table replaces the 3-row table.
- **CHANGELOG.md** — `[Unreleased]` populated with the new surface.
- **`.github/copilot-instructions.md`** — extension-method list
  updated.

## Stacking

Top of the vNext stack. Bases on `feature/114-benchmark-twe` (PR #129).