### PR TITLE
fix: 3 Copilot follow-ups from PR #120 review

### DIFF
--- a/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
+++ b/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
@@ -356,10 +356,12 @@ public static class ICollectionExtensions
         }
 
         // Fast path: HashSet<T> already exposes a native RemoveWhere that
-        // avoids the temp-list allocation + second pass below. Skipped for
-        // List<T> because List<T>.RemoveAll on netstandard2.0/net462 was a
-        // late addition and the in-place enumerator pattern below is just
-        // as cheap for the small-to-medium sizes typical of this extension.
+        // avoids the temp-list allocation + second pass below. We don't
+        // special-case List<T>.RemoveAll (which has shipped since .NET
+        // Framework 2.0) because the generic two-pass pattern handles
+        // every other ICollection<T> uniformly and the extra type-check
+        // cost outweighs the savings at the small-to-medium sizes typical
+        // for this extension.
         if (source is HashSet<T> set)
         {
             return set.RemoveWhere(item => predicate(item));
@@ -441,16 +443,28 @@ public static class ICollectionExtensions
     /// <remarks>
     /// Containment is determined by the target collection's own
     /// <see cref="ICollection{T}.Contains"/> implementation, which usually
-    /// uses <see cref="EqualityComparer{T}.Default"/>. <see cref="HashSet{T}"/>'s
-    /// own <see cref="HashSet{T}.Add"/> already returns a Boolean to the
-    /// same effect; this extension generalises the behaviour to every
-    /// <see cref="ICollection{T}"/>.
+    /// uses <see cref="EqualityComparer{T}.Default"/>. When
+    /// <paramref name="source"/> is an <see cref="ISet{T}"/> the call is
+    /// delegated to <see cref="ISet{T}.Add"/>, which returns the same
+    /// Boolean signal in a single lookup (and preserves the set's native
+    /// equality semantics, e.g. a custom <see cref="IEqualityComparer{T}"/>).
+    /// For other <see cref="ICollection{T}"/> implementations the
+    /// extension generalises the behaviour using
+    /// <see cref="ICollection{T}.Contains"/> + <see cref="ICollection{T}.Add"/>.
     /// </remarks>
     public static bool AddIfNotContains<T>(this ICollection<T> source, T item)
     {
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
+        }
+
+        // Fast path: ISet<T> (HashSet<T>, SortedSet<T>, etc.) — ISet.Add
+        // already returns the "did we add?" Boolean in a single lookup,
+        // so we skip the redundant Contains call.
+        if (source is ISet<T> set)
+        {
+            return set.Add(item);
         }
 
         if (source.Contains(item))

--- a/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
+++ b/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
@@ -11,10 +11,11 @@
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(Version)', '[-+].*$', '')).0</FileVersion>
 		<Title>$(AssemblyName)</Title>
-		<Authors>Chris Wolfgang</Authors>
+		<!-- <Authors> and <Copyright> are inherited from Directory.Build.props
+		     (canonical CI3 defaults). Re-defining them here would duplicate the
+		     fleet-wide values and drift over time. -->
 		<Description>A collection of extension methods for types that implement ICollection&lt;T&gt;</Description>
 		<PackageTags>icollection;collection;extensions;extension-methods;addrange;dotnet;netstandard</PackageTags>
-		<Copyright>Copyright 2026 Chris Wolfgang</Copyright>
 		<PackageProjectUrl>https://github.com/Chris-Wolfgang/ICollection-Extensions</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Chris-Wolfgang/ICollection-Extensions.git</RepositoryUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/tests/Wolfgang.Extensions.ICollection.Tests.Unit/ICollectionExtensionTests.cs
+++ b/tests/Wolfgang.Extensions.ICollection.Tests.Unit/ICollectionExtensionTests.cs
@@ -748,6 +748,22 @@ public class ICollectionExtensionTests
 
 
     [Fact]
+    public void AddIfNotContains_single_uses_ISet_Add_when_source_is_HashSet()
+    {
+        // HashSet<T> is ISet<T> — the extension's ISet fast path should
+        // delegate to set.Add (one lookup) instead of Contains+Add (two).
+        // We can't directly observe the call count, but behaviour parity
+        // is the contract: returns the same Boolean as a direct set.Add
+        // would have.
+        ICollection<int> source = new HashSet<int> { 1, 2 };
+        Assert.True(source.AddIfNotContains(3));
+        Assert.False(source.AddIfNotContains(2));
+        Assert.Equal(new[] { 1, 2, 3 }, ((HashSet<int>)source));
+    }
+
+
+
+    [Fact]
     public void AddIfNotContains_many_when_source_is_null_throws_ArgumentNullException()
     {
         ICollection<int> source = null!;


### PR DESCRIPTION
## Summary

Three follow-up findings from the second Copilot review pass on
PR #120 (vNext → main). Opening as a separate PR per request rather
than pushing directly to vNext.

## Findings addressed

### 1. `RemoveWhere` comment was wrong
Claimed `List<T>.RemoveAll` was a "late addition" on
`netstandard2.0`/`net462`. It actually shipped in **.NET Framework
2.0** and has been part of every BCL since. Rewrote the comment to
give the real rationale for not special-casing `List<T>`: the
generic two-pass pattern handles every `ICollection<T>` uniformly
and the type-check cost outweighs the savings at typical sizes.

### 2. `AddIfNotContains` now has an `ISet<T>` fast path
Previously did `Contains` + `Add` (two lookups) for every receiver.
`ISet<T>.Add` already returns the "did we add?" Boolean in a single
lookup, so the extension now delegates to it. Bonus: the set's
native `IEqualityComparer<T>` is honoured automatically (was
previously routed through `ICollection<T>.Contains`'s default
comparer). New test covers parity for `HashSet<int>` typed as
`ICollection<int>`.

### 3. csproj `<Authors>` / `<Copyright>` removed
The canonical CI3 work added both fields to `Directory.Build.props`
(`<Authors>Chris Wolfgang</Authors>`,
`<Copyright>Copyright (c) Chris Wolfgang</Copyright>`). The csproj's
duplicates had drifted (`Copyright 2026` vs DBP's year-less
`Copyright (c)`). Dropped both from the csproj with a comment
pointing at the DBP defaults; the year-less DBP form is intentional
so it doesn't need yearly bumps.

## Verification

- Build: 0 warnings, 0 errors with TWE active
- Tests: 72 passing on net10.0 (71 + 1 new ISet parity test)

## Stacking

Targets `vNext`. After merge, vNext picks these up and PR #120's
admin-bypass merge brings them onto main.