### PR TITLE
Protected canonical sync from vNext (admin-bypass)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,13 +25,12 @@ indent_size = 2
 [*.{yml,yaml}]
 indent_size = 2
 
-# PowerShell files
-# PowerShell uses CRLF to maintain compatibility with Windows and PowerShell conventions
-# This overrides the global end_of_line = lf setting and aligns with .gitattributes line 14
-[*.ps1]
-indent_size = 4
-end_of_line = crlf
-charset = utf-8-bom
+# PowerShell scripts inherit LF + UTF-8 (no BOM) + 4-space indent from
+# the global [*] section above — no per-language override is needed.
+# LF + no-BOM is required for the `#!/usr/bin/env pwsh` shebang (where
+# present) on scripts under scripts/ to work on Linux/macOS — CR
+# breaks the kernel's exec lookup, and a leading BOM prevents shebang
+# recognition entirely.
 
 # C# files
 [*.cs]

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,11 +9,13 @@
 *.fsx text eol=lf
 
 # Scripts
-# PowerShell scripts: CRLF line endings (intentional override)
-# Both .gitattributes and .editorconfig consistently configure PowerShell files
-# to use CRLF (Windows-style) line endings for PowerShell convention compliance.
-# See .editorconfig [*.ps1] section for the matching configuration.
-*.ps1 text eol=crlf
+# PowerShell scripts: LF line endings + no BOM.
+# `.editorconfig` no longer has a `[*.ps1]` override — falling back to the
+# repo defaults (`charset = utf-8`, no BOM, LF) — because `#!/usr/bin/env pwsh`
+# shebangs require LF + no-BOM on Linux/macOS to execute correctly. Keeping
+# `.gitattributes` aligned to LF here so checkout doesn't re-introduce CRLF
+# on Windows clones.
+*.ps1 text eol=lf
 
 
 # Build and configuration files

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,111 @@
+name: Benchmarks
+
+# Runs BenchmarkDotNet after a merge to main, then publishes the results to
+# the gh-pages branch under /dev/bench/ where benchmark-action/github-action-benchmark
+# renders an interactive line chart.
+#
+# This workflow is decoupled from PR validation and release: it does NOT gate
+# merging or publishing — it just adds one data point per qualifying push.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+      - '.github/workflows/benchmarks.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize all writes to the gh-pages branch — both within this workflow
+# (two main pushes close together) and across workflows that also publish
+# to gh-pages (docfx.yaml, release.yaml). The shared `gh-pages` group name
+# means GitHub Actions queues any of those jobs behind the others when
+# they overlap, preventing non-fast-forward push failures and lost
+# updates. cancel-in-progress: false — every merge represents a meaningful
+# data point, so we queue rather than discard.
+#
+# NOTE: docfx.yaml and release.yaml currently have no `concurrency:` block,
+# so cross-workflow serialization is only partial today. Adding the same
+# `gh-pages` group to those workflows is tracked as a fleet-wide follow-up.
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    name: Run BenchmarkDotNet & publish chart
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required to push the rendered chart + history to the gh-pages branch.
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj
+
+      - name: Build (Release)
+        run: dotnet build -c Release --no-restore benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj
+
+      - name: Run benchmarks
+        working-directory: benchmarks/Wolfgang.Extensions.ICollection.Benchmarks
+        # ShortRun keeps total runtime small (~3-5 min). GitHub-hosted runners
+        # are noisy, so chart trends are reliable for allocations and double-digit
+        # time changes; smaller deltas are not.
+        run: dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
+
+      - name: Merge per-class BDN reports
+        id: locate
+        working-directory: benchmarks/Wolfgang.Extensions.ICollection.Benchmarks
+        run: |
+          # BDN's --exporters json writes one *-report-full-compressed.json per
+          # benchmark class. github-action-benchmark consumes a single file, so
+          # we combine the .Benchmarks arrays into one synthetic report.
+          # nullglob: empty match expands to nothing (instead of the literal
+          # pattern), so the explicit "no report found" branch can run before
+          # set -e + pipefail aborts the step.
+          shopt -s nullglob
+          reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "::error::No BenchmarkDotNet JSON report found"
+            exit 1
+          fi
+          echo "Merging ${#reports[@]} report(s):"
+          printf '  %s\n' "${reports[@]}"
+          jq -s '{
+            Title: "BenchmarkDotNet combined report",
+            HostEnvironmentInfo: .[0].HostEnvironmentInfo,
+            Benchmarks: [.[].Benchmarks[]]
+          }' "${reports[@]}" > benchmarks-result.json
+          echo "report=benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
+
+      - name: Publish chart to gh-pages
+        # Pinned to v1.22.1 commit per repo convention (third-party actions
+        # publishing to gh-pages are pinned by SHA, not mutable tag).
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba  # v1.22.1
+        with:
+          name: BenchmarkDotNet
+          tool: 'benchmarkdotnet'
+          output-file-path: ${{ steps.locate.outputs.report }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Don't fail the workflow if a metric regresses — this is a tracker,
+          # not a gate. Tighten later if the noise floor settles.
+          alert-threshold: '200%'
+          fail-on-alert: false

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -39,6 +39,14 @@ jobs:
     name: Run BenchmarkDotNet & publish chart
     runs-on: ubuntu-latest
 
+    # Skip the run when the benchmark project isn't yet in the tree on
+    # main. The workflow ships in the protected-files sync ahead of the
+    # feature stack that introduces the project, so during that brief
+    # window every qualifying push to main would otherwise fail at the
+    # 'dotnet restore' step. hashFiles() returns '' when the path glob
+    # matches nothing.
+    if: hashFiles('benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj') != ''
+
     permissions:
       # Required to push the rendered chart + history to the gh-pages branch.
       contents: write

--- a/.github/workflows/build-all-versions.yaml
+++ b/.github/workflows/build-all-versions.yaml
@@ -76,8 +76,6 @@ jobs:
           )
           Write-Host "Discovered $($versions.Count) version tag(s): $($versions -join ', ')"
 
-          $failedVersions = @()
-
           foreach ($version in $versions) {
             Write-Host "========================================" -ForegroundColor Cyan
             Write-Host "Building docs for $version" -ForegroundColor Cyan
@@ -96,7 +94,6 @@ jobs:
             git worktree add $workDir $version
             if ($LASTEXITCODE -ne 0) {
               Write-Warning "⚠️  Failed to create worktree for $version – skipping."
-              $failedVersions += $version
               continue
             }
 
@@ -144,7 +141,6 @@ jobs:
                 Write-Host "✅ Docs built for $version" -ForegroundColor Green
               } else {
                 Write-Warning "⚠️  No _site output produced for $version."
-                $failedVersions += $version
               }
             } finally {
               Pop-Location
@@ -153,12 +149,6 @@ jobs:
                 Write-Warning "⚠️  git worktree remove failed for $version (exit $LASTEXITCODE): $removeOutput"
               }
             }
-          }
-
-          if ($failedVersions.Count -gt 0) {
-            Write-Warning "⚠️  Failed to build docs for: $($failedVersions -join ', ')"
-            Write-Error "❌ $($failedVersions.Count) version(s) failed — aborting to avoid deploying incomplete docs."
-            exit 1
           }
 
           # Build 'latest' from the most recent stable v*.*.* tag so that the
@@ -275,10 +265,20 @@ jobs:
           $repoName = ($env:GITHUB_REPOSITORY -split '/')[-1]
           $base = if ($repoName) { "/$repoName/" } else { "/" }
 
+          # Derive versions.json from the directories actually produced by
+          # earlier steps in this workflow (not from raw git tags). If a
+          # docfx build failed for a tag, no folder lands under
+          # all_version_docs/versions/<tag>/, so it must not appear in the
+          # version picker — otherwise the picker would link to a 404.
           $semverRe = '^v(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>[0-9A-Za-z.-]+))?$'
-          $tags = git tag -l 'v*' | Where-Object { $_ -ne '' }
+          $versionsRoot = Join-Path $outDir 'versions'
+          $builtDirs = if (Test-Path $versionsRoot) {
+            Get-ChildItem -Path $versionsRoot -Directory | Where-Object { $_.Name -ne 'latest' } | Select-Object -ExpandProperty Name
+          } else {
+            @()
+          }
 
-          $taggedVersions = foreach ($t in $tags) {
+          $taggedVersions = foreach ($t in $builtDirs) {
             if ($t -match $semverRe) {
               $stable = if ([string]::IsNullOrEmpty($Matches['prerelease'])) { 1 } else { 0 }
               [PSCustomObject]@{
@@ -295,17 +295,9 @@ jobs:
             Sort-Object -Property Major, Minor, Patch, Stable -Descending |
             Select-Object -ExpandProperty Tag
 
-          # Derive versions list from actually built output directories (not all tags)
-          # to avoid linking to versions that failed to build
-          $builtDirs = Get-ChildItem -Path (Join-Path $outDir 'versions') -Directory | Select-Object -ExpandProperty Name
-          [array]$versions = @()
-          if ($builtDirs -contains 'latest') {
-            $versions += [PSCustomObject]@{ version = 'latest'; url = "${base}versions/latest/" }
-          }
+          [array]$versions = @([PSCustomObject]@{ version = 'latest'; url = "${base}versions/latest/" })
           foreach ($t in $orderedTags) {
-            if ($builtDirs -contains $t) {
-              $versions += [PSCustomObject]@{ version = $t; url = "${base}versions/$t/" }
-            }
+            $versions += [PSCustomObject]@{ version = $t; url = "${base}versions/$t/" }
           }
 
           $versionsJson = ConvertTo-Json -InputObject $versions -Depth 3

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -80,12 +80,35 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
+        # security-extended adds the broader security query pack on top of the
+        # default queries (more rules, slightly longer scans).
+        queries: security-extended
 
     - name: Setup .NET
       if: steps.check-csharp.outputs.has-csharp == 'true'
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '10.0.x'
+
+    - name: Restore .NET workloads
+      if: steps.check-csharp.outputs.has-csharp == 'true'
+      shell: pwsh
+      run: |
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads
+        # via their TFMs (e.g. net10.0-android). Install whatever the solution needs
+        # before restore. For pure libraries this is a fast no-op.
+        $solution = Get-ChildItem -Path . -Recurse -Depth 2 -Include "*.sln", "*.slnx" | Select-Object -First 1
+        if ($solution) {
+          Write-Host "Restoring workloads for $($solution.FullName)"
+          dotnet workload restore $solution.FullName
+        } else {
+          Write-Host "No solution found; restoring workloads for all projects"
+          dotnet workload restore
+        }
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "dotnet workload restore failed with exit code $LASTEXITCODE"
+          exit $LASTEXITCODE
+        }
 
     - name: Build for CodeQL Analysis
       id: build

--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -101,6 +101,30 @@ jobs:
           Get-ChildItem "docfx_project/_site/api"
         shell: pwsh
 
+      - name: Generate code-coverage report into docs site (T1)
+        # Initiative T1 — publish coverage report to gh-pages alongside docs.
+        # Runs the test suite with Cobertura coverage collection, then uses
+        # ReportGenerator to render an HTML report into _site/coverage/.
+        # The published docs site gains a /coverage/ subpath.
+        # continue-on-error means a coverage failure (no tests, flaky tests,
+        # report generation issues) does not block the docs deploy.
+        if: hashFiles('tests/**/*.csproj') != ''
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          dotnet test --configuration Release --no-build --collect:"XPlat Code Coverage" --results-directory ./coverage-raw 2>&1 | Out-Host
+          dotnet tool install -g dotnet-reportgenerator-globaltool 2>$null
+          $coverageFiles = @(Get-ChildItem -Path ./coverage-raw -Recurse -Filter "coverage.cobertura.xml" -ErrorAction SilentlyContinue)
+          if ($coverageFiles.Count -eq 0) {
+            Write-Host "::notice::No coverage files generated - skipping coverage report step"
+            exit 0
+          }
+          $reports = ($coverageFiles | ForEach-Object { $_.FullName }) -join ';'
+          $outDir = "docfx_project/_site/coverage"
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+          reportgenerator "-reports:$reports" "-targetdir:$outDir" "-reporttypes:Html;TextSummary"
+          Write-Host "Coverage report written to $outDir"
+
       - name: Generate versions.json
         # Produces versions.json consumed by the DocFX version-switcher dropdown.
         # Site layout:
@@ -170,8 +194,13 @@ jobs:
             $maxLen = [Math]::Max($aIds.Length, $bIds.Length)
 
             for ($i = 0; $i -lt $maxLen; $i++) {
-              if ($i -ge $aIds.Length) { return -1 } # a has fewer identifiers -> lower precedence
-              if ($i -ge $bIds.Length) { return 1 }  # b has fewer identifiers -> lower precedence
+              # SemVer §11.4.4: fewer prerelease identifiers = lower precedence.
+              # In *descending* order (newest first), the lower-precedence
+              # value sorts AFTER the higher-precedence one, so the comparator
+              # must return positive when 'a' is the shorter (lower-precedence)
+              # one and negative when 'b' is.
+              if ($i -ge $aIds.Length) { return 1 }  # a has fewer identifiers -> lower precedence -> sorts later
+              if ($i -ge $bIds.Length) { return -1 } # b has fewer identifiers -> lower precedence -> sorts later
 
               $aId = $aIds[$i]
               $bId = $bIds[$i]
@@ -220,65 +249,47 @@ jobs:
             Set-Content -Path 'docfx_project/_site/versions.json' -Encoding utf8NoBOM
           Write-Host "Generated versions.json with $($versions.Count) version(s): $($versions | ForEach-Object { $_.version })"
 
-      - name: Clean up stale root files from gh-pages
-        # Before deploying the latest docs to the site root, remove any pre-existing
-        # root-level files and folders from the gh-pages branch (except the versions/
-        # directory, CNAME, and .nojekyll) so that stale DocFX assets from a previous
-        # build do not linger on the live site.
-        # The versions/ folder is preserved so that all versioned docs remain accessible
-        # while the root is refreshed with the new build.
-        if: inputs.deploy_to_pages != false && inputs.deploy_as_latest != false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify previous versions preserved in versions.json
+        # Initiative D6 — guard against accidentally wiping the version selector.
+        # Fetches the currently-deployed versions.json from gh-pages and confirms
+        # the newly-generated one has at least as many entries AND retains every
+        # previously-published version label. If anything shrunk or went missing,
+        # abort the deploy so the version selector cannot be wiped by accident.
         shell: pwsh
         run: |
-          $branchExists = git ls-remote --heads origin gh-pages
-          if (-not $branchExists) {
-            Write-Host "ℹ️ gh-pages branch does not exist yet – skipping stale-file cleanup."
+          $newPath = 'docfx_project/_site/versions.json'
+          if (-Not (Test-Path $newPath)) {
+            Write-Host "::notice::No new versions.json produced - skipping preservation check."
             exit 0
           }
-
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git remote set-url origin "https://x-access-token:$($env:GITHUB_TOKEN)@github.com/$($env:GITHUB_REPOSITORY).git"
-
-          git fetch origin gh-pages
-          # Create a local tracking branch only if it does not already exist
-          git show-ref --verify --quiet refs/heads/gh-pages
-          if ($LASTEXITCODE -ne 0) {
-            git branch gh-pages origin/gh-pages
+          $existingUrl = "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/versions.json"
+          try {
+            $existingRaw = (Invoke-WebRequest -Uri $existingUrl -ErrorAction Stop).Content
+          } catch {
+            Write-Host "::notice::No existing versions.json at $existingUrl - first deploy, skipping preservation check."
+            exit 0
           }
-
-          $WORK_DIR = Join-Path $env:RUNNER_TEMP 'gh-pages-clean'
-          # Remove a leftover worktree from a previous failed run, if any
-          git worktree remove "$WORK_DIR" --force 2>&1 | Out-Null
-          if (Test-Path $WORK_DIR) { Remove-Item $WORK_DIR -Recurse -Force }
-          git worktree add "$WORK_DIR" gh-pages
-
-          # Remove all root-level items EXCEPT:
-          #   .git         – Git metadata (worktree pointer file)
-          #   CNAME        – Custom domain config (if present)
-          #   .nojekyll    – Tells GitHub Pages not to run Jekyll
-          #   versions/    – All versioned docs (v1.0.0/, latest/, etc.)
-          Get-ChildItem -Path $WORK_DIR -Force | Where-Object {
-            $_.Name -ne '.git' -and
-            $_.Name -ne 'CNAME' -and
-            $_.Name -ne '.nojekyll' -and
-            $_.Name -ne 'versions'
-          } | Remove-Item -Recurse -Force
-
-          git -C "$WORK_DIR" add -A
-          git -C "$WORK_DIR" diff --cached --quiet
-          if ($LASTEXITCODE -ne 0) {
-            git -C "$WORK_DIR" commit `
-              -m "chore: clean up stale root DocFX assets before redeploy [skip ci]"
-            git -C "$WORK_DIR" push origin HEAD:gh-pages
-            Write-Host "✅ Stale root files removed from gh-pages."
-          } else {
-            Write-Host "ℹ️ No stale files found in gh-pages root – nothing to clean."
+          try {
+            $existing = $existingRaw | ConvertFrom-Json
+            $new = Get-Content $newPath -Raw | ConvertFrom-Json
+          } catch {
+            Write-Error "Failed to parse versions.json: $($_.Exception.Message)"
+            exit 1
           }
-
-          git worktree remove "$WORK_DIR" --force
+          $existingCount = @($existing).Count
+          $newCount = @($new).Count
+          if ($newCount -lt $existingCount) {
+            Write-Error "versions.json would lose entries: existing=$existingCount, new=$newCount. Aborting deploy."
+            exit 1
+          }
+          $existingVersions = @($existing) | ForEach-Object { $_.version }
+          $newVersions = @($new) | ForEach-Object { $_.version }
+          $missing = @($existingVersions | Where-Object { $_ -notin $newVersions })
+          if ($missing.Count -gt 0) {
+            Write-Error "Previous versions missing from new versions.json: $($missing -join ', '). Aborting deploy."
+            exit 1
+          }
+          Write-Host "versions.json preservation OK: existing=$existingCount, new=$newCount."
 
       - name: Compute destination directory
         # Determines the versioned subfolder name for the docs deployment (e.g. /v1.2.3/).
@@ -328,90 +339,149 @@ jobs:
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          git remote set-url origin "https://x-access-token:$($env:GITHUB_TOKEN)@github.com/$($env:GITHUB_REPOSITORY).git"
 
           $WORK_DIR = Join-Path $env:RUNNER_TEMP 'gh-pages-deploy'
-          $siteDir  = Resolve-Path 'docfx_project/_site'
+          # Default to $false so the finally block uses the safe (Remove-Item)
+          # cleanup if the try block fails before $useWorktree is assigned.
+          $useWorktree = $false
+          $deployExitCode = 0
 
-          # Set up gh-pages worktree (or start fresh if the branch does not exist yet)
-          $branchExists = git ls-remote --heads origin gh-pages
-          if ($branchExists) {
-            git fetch origin gh-pages
-            git show-ref --verify --quiet refs/heads/gh-pages
-            if ($LASTEXITCODE -ne 0) { git branch gh-pages origin/gh-pages }
-            git worktree remove $WORK_DIR --force 2>&1 | Out-Null
-            if (Test-Path $WORK_DIR) { Remove-Item $WORK_DIR -Recurse -Force }
-            git worktree add $WORK_DIR gh-pages
-          } else {
-            Write-Host "ℹ️ gh-pages does not exist yet — starting fresh."
-            New-Item -ItemType Directory -Force -Path $WORK_DIR | Out-Null
-          }
+          try {
+            # Authenticate via http.extraheader rather than embedding the token in
+            # the remote URL. This keeps the token out of `git remote -v` and
+            # error-message output, and avoids writing it into per-repo .git/config.
+            # The finally block ALWAYS unsets this so an early `exit` (e.g. failed
+            # ls-remote, missing template) cannot leave the token in the runner's
+            # global git config for subsequent steps.
+            $basicAuth = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("x-access-token:$($env:GITHUB_TOKEN)"))
+            git config --global http."https://github.com/".extraheader "AUTHORIZATION: basic $basicAuth"
+            git remote set-url origin "https://github.com/$($env:GITHUB_REPOSITORY).git"
 
-          # Remove stale root files; preserve versions/, .git, .nojekyll, CNAME
-          Get-ChildItem -Path $WORK_DIR -Force | Where-Object {
-            $_.Name -notin @('.git', 'CNAME', '.nojekyll', 'versions')
-          } | Remove-Item -Recurse -Force
+            $siteDir = Resolve-Path 'docfx_project/_site'
 
-          # Ensure .nojekyll exists so GitHub Pages does not run Jekyll
-          New-Item -ItemType File -Path (Join-Path $WORK_DIR '.nojekyll') -Force | Out-Null
-
-          # Deploy versioned docs (real DocFX index.html — before version picker overwrites it)
-          $versionedDir = Join-Path $WORK_DIR "versions/$($env:VERSION_DIR)"
-          New-Item -ItemType Directory -Force -Path $versionedDir | Out-Null
-          Copy-Item -Path "$siteDir/*" -Destination $versionedDir -Recurse -Force
-          Write-Host "✅ Copied docs to versions/$($env:VERSION_DIR)/"
-
-          if ($env:DEPLOY_AS_LATEST -eq 'true') {
-            # Deploy to versions/latest/ (real DocFX index.html)
-            $latestDir = Join-Path $WORK_DIR 'versions/latest'
-            New-Item -ItemType Directory -Force -Path $latestDir | Out-Null
-            Copy-Item -Path "$siteDir/*" -Destination $latestDir -Recurse -Force
-            Write-Host "✅ Copied docs to versions/latest/"
-
-            # Generate version-picker index.html and overwrite _site/index.html.
-            # This happens AFTER the versioned copies above, so those directories
-            # retain the real DocFX landing page while the root gets the picker.
-            $repoName = ($env:GITHUB_REPOSITORY -split '/')[-1]
-            $title    = if ($repoName) { "$repoName Documentation" } else { "Documentation" }
-            $versions = Get-Content "$siteDir/versions.json" -Raw | ConvertFrom-Json
-
-            $listItems = foreach ($v in $versions) {
-              $liClass = if ($v.version -eq 'latest') { ' class="latest"' } else { '' }
-              $label   = if ($v.version -eq 'latest') { 'latest (stable)' } else { $v.version }
-              "      <li${liClass}><a href=`"$($v.url)`">$label</a></li>"
+            # Set up gh-pages worktree (or start fresh if the branch does not exist yet).
+            # ls-remote can succeed-with-empty-output (branch missing) or fail
+            # (auth/network). Distinguish the two via $LASTEXITCODE so a transient
+            # failure does not silently route into the bootstrap path and clobber
+            # an existing gh-pages branch.
+            $branchExists = git ls-remote --heads origin gh-pages
+            if ($LASTEXITCODE -ne 0) {
+              # `throw` (not `exit 1`) so the outer try/finally cleanup runs and
+              # the global http.extraheader auth header is always unset.
+              throw "git ls-remote --heads origin gh-pages failed with exit code $LASTEXITCODE — aborting before we accidentally bootstrap over an existing gh-pages branch."
             }
-            $listHtml = $listItems -join "`n"
-
-            if (-not (Test-Path '.github/version-picker-template.html')) {
-              Write-Error "Error: .github/version-picker-template.html not found; cannot generate root index.html."
-              exit 1
-            }
-
-            $template = Get-Content '.github/version-picker-template.html' -Raw
-            $html = $template -replace '\{\{TITLE\}\}', $title `
-                              -replace '\{\{VERSION_LIST\}\}', $listHtml
-            $html | Set-Content -Path "$siteDir/index.html" -Encoding utf8NoBOM
-            Write-Host "Generated version-picker index.html with $($versions.Count) version link(s)."
-
-            # Deploy version picker + shared assets to site root
-            Copy-Item -Path "$siteDir/*" -Destination $WORK_DIR -Recurse -Force
-            Write-Host "✅ Copied version picker to site root"
-          }
-
-          # Single commit and push
-          git -C $WORK_DIR add -A
-          git -C $WORK_DIR diff --cached --quiet
-          if ($LASTEXITCODE -ne 0) {
-            $msg = if ($env:DEPLOY_AS_LATEST -eq 'true') {
-              "docs: deploy $($env:VERSION_DIR) and update latest"
+            $useWorktree = [bool]$branchExists
+            if ($useWorktree) {
+              git fetch origin gh-pages
+              if ($LASTEXITCODE -ne 0) { throw "git fetch origin gh-pages failed with exit code $LASTEXITCODE" }
+              git show-ref --verify --quiet refs/heads/gh-pages
+              if ($LASTEXITCODE -ne 0) { git branch gh-pages origin/gh-pages }
+              git worktree remove $WORK_DIR --force 2>&1 | Out-Null
+              if (Test-Path -LiteralPath $WORK_DIR) { Remove-Item -LiteralPath $WORK_DIR -Recurse -Force }
+              git worktree add $WORK_DIR gh-pages
+              if ($LASTEXITCODE -ne 0) { throw "git worktree add $WORK_DIR gh-pages failed with exit code $LASTEXITCODE" }
             } else {
-              "docs: deploy $($env:VERSION_DIR)"
+              Write-Host "ℹ️ gh-pages does not exist yet — starting fresh."
+              New-Item -ItemType Directory -Force -Path $WORK_DIR | Out-Null
+              # Initialize an empty repo on the gh-pages branch so the later
+              # add/commit/push commands have a real git repository to operate on.
+              # Auth is provided by the global http.extraheader configured above,
+              # so the remote URL does not embed the token.
+              git -C $WORK_DIR init --initial-branch=gh-pages
+              if ($LASTEXITCODE -ne 0) { throw "git init in $WORK_DIR failed with exit code $LASTEXITCODE" }
+              git -C $WORK_DIR remote add origin "https://github.com/$($env:GITHUB_REPOSITORY).git"
+              if ($LASTEXITCODE -ne 0) { throw "git remote add origin failed with exit code $LASTEXITCODE" }
             }
-            git -C $WORK_DIR commit -m $msg
-            git -C $WORK_DIR push origin HEAD:gh-pages
-            Write-Host "✅ Documentation deployed in a single commit."
-          } else {
-            Write-Host "ℹ️ No documentation changes to deploy."
+
+            # Remove stale root files; preserve versions/, .git, .nojekyll, CNAME, dev
+            # ('dev' is where benchmark-action/github-action-benchmark stores its
+            # chart + accumulated data.js — wiping it loses chart history on every release.)
+            Get-ChildItem -Path $WORK_DIR -Force | Where-Object {
+              $_.Name -notin @('.git', 'CNAME', '.nojekyll', 'versions', 'dev')
+            } | Remove-Item -Recurse -Force
+
+            # Ensure .nojekyll exists so GitHub Pages does not run Jekyll
+            New-Item -ItemType File -Path (Join-Path $WORK_DIR '.nojekyll') -Force | Out-Null
+
+            # Deploy versioned docs (real DocFX index.html — before version picker overwrites it)
+            $versionedDir = Join-Path $WORK_DIR "versions/$($env:VERSION_DIR)"
+            New-Item -ItemType Directory -Force -Path $versionedDir | Out-Null
+            Copy-Item -Path "$siteDir/*" -Destination $versionedDir -Recurse -Force
+            Write-Host "✅ Copied docs to versions/$($env:VERSION_DIR)/"
+
+            if ($env:DEPLOY_AS_LATEST -eq 'true') {
+              # Deploy to versions/latest/ (real DocFX index.html)
+              $latestDir = Join-Path $WORK_DIR 'versions/latest'
+              New-Item -ItemType Directory -Force -Path $latestDir | Out-Null
+              Copy-Item -Path "$siteDir/*" -Destination $latestDir -Recurse -Force
+              Write-Host "✅ Copied docs to versions/latest/"
+
+              # Generate version-picker index.html and overwrite _site/index.html.
+              # This happens AFTER the versioned copies above, so those directories
+              # retain the real DocFX landing page while the root gets the picker.
+              $repoName = ($env:GITHUB_REPOSITORY -split '/')[-1]
+              $title    = if ($repoName) { "$repoName Documentation" } else { "Documentation" }
+              $versions = Get-Content "$siteDir/versions.json" -Raw | ConvertFrom-Json
+
+              $listItems = foreach ($v in $versions) {
+                $liClass = if ($v.version -eq 'latest') { ' class="latest"' } else { '' }
+                $label   = if ($v.version -eq 'latest') { 'latest (stable)' } else { $v.version }
+                "      <li${liClass}><a href=`"$($v.url)`">$label</a></li>"
+              }
+              $listHtml = $listItems -join "`n"
+
+              if (-not (Test-Path '.github/version-picker-template.html')) {
+                # `throw` (not `exit 1`) so the outer try/finally cleanup runs.
+                throw ".github/version-picker-template.html not found; cannot generate root index.html."
+              }
+
+              $template = Get-Content '.github/version-picker-template.html' -Raw
+              $html = $template -replace '\{\{TITLE\}\}', $title `
+                                -replace '\{\{VERSION_LIST\}\}', $listHtml
+              $html | Set-Content -Path "$siteDir/index.html" -Encoding utf8NoBOM
+              Write-Host "Generated version-picker index.html with $($versions.Count) version link(s)."
+
+              # Deploy version picker + shared assets to site root
+              Copy-Item -Path "$siteDir/*" -Destination $WORK_DIR -Recurse -Force
+              Write-Host "✅ Copied version picker to site root"
+            }
+
+            # Single commit and push
+            git -C $WORK_DIR add -A
+            git -C $WORK_DIR diff --cached --quiet
+            if ($LASTEXITCODE -ne 0) {
+              $msg = if ($env:DEPLOY_AS_LATEST -eq 'true') {
+                "docs: deploy $($env:VERSION_DIR) and update latest"
+              } else {
+                "docs: deploy $($env:VERSION_DIR)"
+              }
+              git -C $WORK_DIR commit -m $msg
+              git -C $WORK_DIR push origin HEAD:gh-pages
+              Write-Host "✅ Documentation deployed in a single commit."
+            } else {
+              Write-Host "ℹ️ No documentation changes to deploy."
+            }
+
+            # Capture the deploy outcome before the finally block runs cleanup
+            # (which might overwrite $LASTEXITCODE with a benign value).
+            $deployExitCode = $LASTEXITCODE
+          }
+          finally {
+            if ($useWorktree) {
+              git worktree remove $WORK_DIR --force 2>&1 | Out-Null
+            } elseif (Test-Path -LiteralPath $WORK_DIR) {
+              Remove-Item -LiteralPath $WORK_DIR -Recurse -Force -ErrorAction SilentlyContinue
+            }
+
+            # ALWAYS unset the http.extraheader so the token (in encoded form)
+            # does not linger in the runner's global git config for any later
+            # step in this job, even if the try block hit an early `exit`.
+            git config --global --unset-all http."https://github.com/".extraheader 2>&1 | Out-Null
           }
 
-          git worktree remove $WORK_DIR --force 2>&1 | Out-Null
+          # PowerShell will not propagate $LASTEXITCODE from a script block as
+          # the step's exit code reliably; explicitly `exit` so a failed
+          # commit/push fails the workflow step.
+          if ($deployExitCode -ne 0) {
+            exit $deployExitCode
+          }

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -274,55 +274,6 @@ jobs:
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 
-      - name: Fetch trusted configuration files from main branch
-        # Skip for Dependabot — its package-version bumps to protected files (e.g.
-        # Directory.Build.props) are legitimate and should not be overwritten by main's
-        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-            ".github/workflows/*.yml"
-            ".github/workflows/*.yaml"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          for config_file in "${config_files[@]}"; do
-            # Handle glob patterns
-            if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              # Check if file exists in main branch
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
       # Fix for .NET 5.0 on Ubuntu 22.04+ - install libssl1.1 from the focal-security
       # repository so APT verifies the package via GPG instead of a plain wget download.
       - name: Install OpenSSL 1.1 for .NET 5.0
@@ -349,6 +300,12 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+
+      - name: Restore .NET workloads
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads via
+        # their TFMs (e.g. net10.0-android). For workload-bearing repos this installs them
+        # before restore; for pure libraries it's a fast no-op.
+        run: dotnet workload restore
 
       - name: Restore and build (exclude .NET Framework-only projects)
         run: |
@@ -615,6 +572,10 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files (e.g.
+        # Directory.Build.props) are legitimate and should not be overwritten by main's
+        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         shell: pwsh
         run: |
           Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
@@ -636,7 +597,7 @@ jobs:
             $exists = git cat-file -e "main-branch:$configFile" 2>&1
             if ($LASTEXITCODE -eq 0) {
               Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8 -NoNewline
+              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8NoBOM -NoNewline
             } else {
               Write-Host "  ℹ️  $configFile not found in main branch, skipping"
             }
@@ -651,56 +612,11 @@ jobs:
                 Write-Host "  ✓ Copying $file from main branch"
                 $dir = Split-Path -Parent $file
                 if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8 -NoNewline
+                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8NoBOM -NoNewline
               }
             }
           }
           
-          Write-Host ""
-          Write-Host "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        shell: pwsh
-        run: |
-          Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          $configFiles = @(
-            ".editorconfig",
-            "Directory.Build.props",
-            "Directory.Build.targets",
-            "BannedSymbols.txt"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          foreach ($configFile in $configFiles) {
-            # Check if file exists in main branch
-            $exists = git cat-file -e "main-branch:$configFile" 2>&1
-            if ($LASTEXITCODE -eq 0) {
-              Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8 -NoNewline
-            } else {
-              Write-Host "  ℹ️  $configFile not found in main branch, skipping"
-            }
-          }
-
-          # Handle glob patterns for .globalconfig, .ruleset, and workflow files
-          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
-          foreach ($pattern in $globPatterns) {
-            $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
-            foreach ($file in $files) {
-              if ($file) {
-                Write-Host "  ✓ Copying $file from main branch"
-                $dir = Split-Path -Parent $file
-                if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8 -NoNewline
-              }
-            }
-          }
-
           Write-Host ""
           Write-Host "✅ Configuration files secured - using versions from main branch"
 
@@ -715,6 +631,12 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+
+      - name: Restore .NET workloads
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads via
+        # their TFMs (e.g. net10.0-android). For workload-bearing repos this installs them
+        # before restore; for pure libraries it's a fast no-op.
+        run: dotnet workload restore
 
       - name: Restore dependencies
         run: dotnet restore
@@ -954,55 +876,6 @@ jobs:
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 
-      - name: Fetch trusted configuration files from main branch
-        # Skip for Dependabot — its package-version bumps to protected files (e.g.
-        # Directory.Build.props) are legitimate and should not be overwritten by main's
-        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-            ".github/workflows/*.yml"
-            ".github/workflows/*.yaml"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          for config_file in "${config_files[@]}"; do
-            # Handle glob patterns
-            if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              # Check if file exists in main branch
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -1012,6 +885,12 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+
+      - name: Restore .NET workloads
+        # Some projects (MAUI / MauiHybrid / Android / iOS / WPF) declare workloads via
+        # their TFMs (e.g. net10.0-android). For workload-bearing repos this installs them
+        # before restore; for pure libraries it's a fast no-op.
+        run: dotnet workload restore
 
       - name: Restore and build (exclude .NET Framework-only projects)
         run: |
@@ -1334,55 +1213,6 @@ jobs:
             fi
           done
           
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        # Skip for Dependabot — its package-version bumps to protected files (e.g.
-        # Directory.Build.props) are legitimate and should not be overwritten by main's
-        # older versions. Dependabot's identity is GitHub-controlled and not spoofable.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-            ".github/workflows/*.yml"
-            ".github/workflows/*.yaml"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          for config_file in "${config_files[@]}"; do
-            # Handle glob patterns
-            if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              # Check if file exists in main branch
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -563,9 +563,77 @@ jobs:
           if-no-files-found: warn
 
   # Publish to NuGet (only if validation passed)
+  # Verify the documentation builds cleanly BEFORE publishing the release —
+  # initiative D8. Builds DocFX without deploying so a docs failure blocks
+  # publish-nuget rather than landing after the package is already live.
+  verify-docs-build:
+    name: Verify Documentation Builds
+    runs-on: windows-latest
+    if: github.repository != 'Chris-Wolfgang/repo-template'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Detect docfx project
+        id: check
+        shell: pwsh
+        run: |
+          if (Test-Path "docfx_project/docfx.json") {
+            "found=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } else {
+            Write-Host "::notice::No docfx_project/docfx.json - skipping docs verification."
+            "found=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          }
+
+      - name: Setup .NET
+        if: steps.check.outputs.found == 'true'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Restore dependencies
+        if: steps.check.outputs.found == 'true'
+        run: dotnet restore
+
+      - name: Build solution (Release)
+        if: steps.check.outputs.found == 'true'
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Install DocFX
+        if: steps.check.outputs.found == 'true'
+        run: dotnet tool update docfx --global || dotnet tool install docfx --global
+
+      - name: Build DocFX metadata
+        if: steps.check.outputs.found == 'true'
+        run: docfx metadata
+        working-directory: docfx_project
+
+      - name: Build documentation (no deploy)
+        if: steps.check.outputs.found == 'true'
+        run: docfx build
+        working-directory: docfx_project
+
+      - name: Verify documentation output
+        if: steps.check.outputs.found == 'true'
+        shell: pwsh
+        run: |
+          if (-Not (Test-Path "docfx_project/_site")) {
+            Write-Error "docfx_project/_site not found after build"
+            exit 1
+          }
+          if (-Not (Test-Path "docfx_project/_site/api")) {
+            Write-Error "docfx_project/_site/api not found - API metadata generation may have failed"
+            exit 1
+          }
+          Write-Host "Documentation built successfully - release may proceed"
+
   publish-nuget:
     name: Publish to NuGet.org
-    needs: pack-and-validate
+    needs: [pack-and-validate, verify-docs-build]
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
     steps:

--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -1,0 +1,89 @@
+# Stryker mutation testing
+#
+# Runs the Stryker.NET mutation tester against the repo's test projects to
+# measure mutation score. Mutation runs are slow — triggered manually
+# (workflow_dispatch) and on a weekly schedule, not on every PR.
+#
+# The workflow looks for a stryker-config.json at the repo root or under
+# tests/**/. If none is present the run is a no-op (Stryker setup is a
+# per-repo follow-up; this file is the canonical infrastructure).
+name: Stryker (mutation testing)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 0' # weekly Sunday 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  stryker:
+    name: Run Stryker
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+
+      - name: Detect stryker-config.json
+        id: check
+        shell: bash
+        run: |
+          # Explicit existence checks rather than globbing — `nullglob` only
+          # drops words that look like patterns (contain *, ?, [). The bare
+          # literal `stryker-config.json` has no glob characters, so it would
+          # be preserved as a literal even when the file doesn't exist, and
+          # the workflow would mistakenly think a config was present.
+          shopt -s globstar nullglob
+          configs=()
+          [ -f stryker-config.json ] && configs+=(stryker-config.json)
+          for cfg in tests/**/stryker-config.json; do
+            [ -f "$cfg" ] && configs+=("$cfg")
+          done
+          if (( ${#configs[@]} )); then
+            printf 'found=true\n' >> "$GITHUB_OUTPUT"
+            printf 'configs<<EOF\n%s\nEOF\n' "${configs[*]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No stryker-config.json found — skipping Stryker run. Add one at repo root or under tests/<project>/ to enable mutation testing."
+            printf 'found=false\n' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.check.outputs.found == 'true'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Install dotnet-stryker
+        if: steps.check.outputs.found == 'true'
+        run: dotnet tool install -g dotnet-stryker
+
+      - name: Run Stryker
+        if: steps.check.outputs.found == 'true'
+        shell: bash
+        run: |
+          set -e
+          shopt -s globstar nullglob
+          if [ -f stryker-config.json ]; then
+            dotnet stryker --config-file stryker-config.json
+          else
+            for cfg in tests/**/stryker-config.json; do
+              dir=$(dirname "$cfg")
+              echo "::group::Stryker in $dir"
+              (cd "$dir" && dotnet stryker)
+              echo "::endgroup::"
+            done
+          fi
+
+      - name: Upload Stryker report
+        if: always() && steps.check.outputs.found == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: stryker-report-${{ github.run_id }}
+          path: |
+            **/StrykerOutput/**
+          if-no-files-found: ignore
+          retention-days: 30

--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -79,4 +79,3 @@ M:System.Console.ReadLine(); Blocking - avoid in async code paths
 M:System.Console.Read(); Blocking - avoid in async code paths
 M:System.Console.ReadKey(); Blocking - avoid in async code paths
 M:System.Console.ReadKey(System.Boolean); Blocking - avoid in async code paths
-

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
+    <Nullable Condition="'$(MSBuildProjectExtension)' == '.csproj'">enable</Nullable>
 
     <!-- Enable .NET analyzers -->
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -56,4 +57,49 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- A1: PublicApiAnalyzers — track public API surface for breaking-change
+         detection. AdditionalFiles below are opt-in PER PROJECT via Exists():
+         drop PublicAPI.Shipped.txt + PublicAPI.Unshipped.txt into a src
+         project directory and the analyzer activates for that project only.
+         Library projects under src/ should opt in; test / example /
+         benchmark projects should not. Per-repo enablement is tracked as a
+         follow-up maintenance issue. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" Condition="Exists('PublicAPI.Shipped.txt')" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" Condition="Exists('PublicAPI.Unshipped.txt')" />
+  </ItemGroup>
+
+
+  <PropertyGroup>
+    <!-- CI3: NuGet package metadata canonical defaults. Per-repo fields
+         (Description, PackageTags, PackageProjectUrl, RepositoryUrl,
+         PackageLicenseExpression, PackageReadmeFile) stay in each src
+         csproj where they are repo-specific. -->
+    <Authors>Chris Wolfgang</Authors>
+    <Company>Chris Wolfgang</Company>
+    <Copyright>Copyright (c) Chris Wolfgang</Copyright>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- SourceLink: embed source provenance into PDBs so debuggers can step
+         into NuGet package code from GitHub. -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Extracted from PR #120 (vNext → main) so the protected-path diff
lands in a small admin-bypass PR rather than tangled in with the
full feature stack. After this merges, **PR #120's diff becomes
entirely unprotected** and can merge without admin bypass.

## Protected files in this PR (10)

- `.editorconfig`
- `Directory.Build.props`
- `BannedSymbols.txt`
- `.github/workflows/benchmarks.yaml` *(new — from P2)*
- `.github/workflows/build-all-versions.yaml`
- `.github/workflows/codeql.yaml`
- `.github/workflows/docfx.yaml`
- `.github/workflows/pr.yaml`
- `.github/workflows/release.yaml`
- `.github/workflows/stryker.yaml` *(new — from T3)*

All come from the canonical-protected + canonical-unprotected fold-in
that has already been validated on vNext via CI on the full feature
stack (#121–#132). Verbatim copy from `origin/vNext`.

## Merge sequence (per the `protected-file-pr-split` skill)

1. **Admin-bypass merge** this PR to `main`
2. Merge `main` → `vNext` locally and push (absorbs these onto vNext)
3. Merge PR #132 (Copilot follow-ups) → vNext if not already merged
4. PR #120 then shows an unprotected-only diff → normal merge (no bypass)
5. Tag `v0.3.0`, push tag, publish GitHub Release → `release.yaml` fires