### PR TITLE
fix: 2 Copilot follow-ups on PR #133 (gitattributes + benchmarks guard)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,11 +9,13 @@
 *.fsx text eol=lf
 
 # Scripts
-# PowerShell scripts: CRLF line endings (intentional override)
-# Both .gitattributes and .editorconfig consistently configure PowerShell files
-# to use CRLF (Windows-style) line endings for PowerShell convention compliance.
-# See .editorconfig [*.ps1] section for the matching configuration.
-*.ps1 text eol=crlf
+# PowerShell scripts: LF line endings + no BOM.
+# `.editorconfig` no longer has a `[*.ps1]` override — falling back to the
+# repo defaults (`charset = utf-8`, no BOM, LF) — because `#!/usr/bin/env pwsh`
+# shebangs require LF + no-BOM on Linux/macOS to execute correctly. Keeping
+# `.gitattributes` aligned to LF here so checkout doesn't re-introduce CRLF
+# on Windows clones.
+*.ps1 text eol=lf
 
 
 # Build and configuration files

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -39,6 +39,14 @@ jobs:
     name: Run BenchmarkDotNet & publish chart
     runs-on: ubuntu-latest
 
+    # Skip the run when the benchmark project isn't yet in the tree on
+    # main. The workflow ships in the protected-files sync ahead of the
+    # feature stack that introduces the project, so during that brief
+    # window every qualifying push to main would otherwise fail at the
+    # 'dotnet restore' step. hashFiles() returns '' when the path glob
+    # matches nothing.
+    if: hashFiles('benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj') != ''
+
     permissions:
       # Required to push the rendered chart + history to the gh-pages branch.
       contents: write


### PR DESCRIPTION
## Summary

Two follow-up findings from Copilot's review on PR #133. Stacks on
top of `protected/vNext-to-main` so the whole protected sync still
lands as a single admin-bypass merge.

## Findings addressed

### 1. `.gitattributes` aligned to LF for `*.ps1`

The canonical `.editorconfig` change in PR #133 dropped its `[*.ps1]`
override (UTF-8-BOM + CRLF) so PS scripts fall back to repo defaults
(LF + no-BOM) — required for `#!/usr/bin/env pwsh` shebangs on
Linux/macOS. But `.gitattributes` still had:

```
*.ps1 text eol=crlf
```

and a stale comment referencing the now-removed `.editorconfig
[*.ps1] section`. Net effect: Windows clones would re-introduce CRLF
on checkout, breaking shebang execution on the same files
`.editorconfig` had carefully normalised.

Changed `.gitattributes` to `*.ps1 text eol=lf` and rewrote the
comment to spell out the shebang reasoning.

### 2. `benchmarks.yaml` no-op guard

The workflow's `dotnet restore` references
`benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj`,
which doesn't exist on `main` until PR #120 (vNext → main) merges.
After #133 lands but before #120 lands, any qualifying push to main
would fail at restore.

Added a job-level `if: hashFiles(...) != ''` guard so the workflow
no-ops gracefully when the project isn't in the tree.

## Stacking

Targets `protected/vNext-to-main` (head of #133). When the admin-
bypass merge lands, both changes go to main as one. PR #120 then
merges normally with the protected diff already in place.