### PR TITLE
fix: round-3 Copilot follow-ups on PR #120 (self-aliasing guards + nits)

### DIFF
--- a/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj
@@ -5,7 +5,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <!-- <Nullable>enable</Nullable> is inherited from Directory.Build.props
+         (canonical fleet-wide default). Redefining it here would duplicate
+         the centralized setting and could drift over time. -->
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
+++ b/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
@@ -263,6 +263,16 @@ public static class ICollectionExtensions
             throw new ArgumentNullException(nameof(items));
         }
 
+        // Self-aliasing guard: callers can legitimately invoke
+        // 'list.RemoveRange(list)' to mean "drop everything". Iterating
+        // 'source' while mutating it would throw InvalidOperationException
+        // on most BCL enumerators; snapshot first so the loop sees a
+        // stable view.
+        if (ReferenceEquals(items, source))
+        {
+            items = new List<T>(source);
+        }
+
         foreach (var item in items)
         {
             source.Remove(item);
@@ -364,7 +374,9 @@ public static class ICollectionExtensions
         // for this extension.
         if (source is HashSet<T> set)
         {
-            return set.RemoveWhere(item => predicate(item));
+            // Use Invoke method-group so the conversion to Predicate<T>
+            // doesn't allocate a closure over `predicate`.
+            return set.RemoveWhere(predicate.Invoke);
         }
 
         var toRemove = new List<T>();
@@ -416,6 +428,15 @@ public static class ICollectionExtensions
         if (items is null)
         {
             throw new ArgumentNullException(nameof(items));
+        }
+
+        // Self-aliasing guard: 'list.ReplaceAll(list)' should be a no-op
+        // (or — for collections where Clear changes identity — at least
+        // not silently wipe the data). Snapshotting before the Clear
+        // means the final state is the original contents copied back in.
+        if (ReferenceEquals(items, source))
+        {
+            items = new List<T>(source);
         }
 
         source.Clear();

--- a/tests/Wolfgang.Extensions.ICollection.Tests.Unit/ICollectionExtensionTests.cs
+++ b/tests/Wolfgang.Extensions.ICollection.Tests.Unit/ICollectionExtensionTests.cs
@@ -544,6 +544,19 @@ public class ICollectionExtensionTests
 
 
     [Fact]
+    public void RemoveRange_when_items_is_same_instance_as_source_removes_all_items()
+    {
+        // Self-aliasing guard: 'list.RemoveRange(list)' must not throw
+        // InvalidOperationException from mutate-during-enumerate. Snapshot
+        // ensures the loop sees a stable view; the final state is empty.
+        ICollection<int> source = new List<int> { 1, 2, 3 };
+        source.RemoveRange(source);
+        Assert.Empty(source);
+    }
+
+
+
+    [Fact]
     public void RemoveRange_when_source_is_ReadOnly_throws_NotSupportedException()
     {
         ICollection<int> source =
@@ -711,6 +724,19 @@ public class ICollectionExtensionTests
 
 
 
+    [Fact]
+    public void ReplaceAll_when_items_is_same_instance_as_source_is_a_no_op()
+    {
+        // Self-aliasing guard: 'list.ReplaceAll(list)' must not silently
+        // wipe the collection (the Clear would otherwise drain the source
+        // before the AddRange enumeration started).
+        ICollection<int> source = new List<int> { 1, 2, 3 };
+        source.ReplaceAll(source);
+        Assert.Equal(new[] { 1, 2, 3 }, source);
+    }
+
+
+
     // =========================================================================
     // AddIfNotContains tests
     // =========================================================================
@@ -755,10 +781,13 @@ public class ICollectionExtensionTests
         // We can't directly observe the call count, but behaviour parity
         // is the contract: returns the same Boolean as a direct set.Add
         // would have.
-        ICollection<int> source = new HashSet<int> { 1, 2 };
+        var set = new HashSet<int> { 1, 2 };
+        ICollection<int> source = set;
         Assert.True(source.AddIfNotContains(3));
         Assert.False(source.AddIfNotContains(2));
-        Assert.Equal(new[] { 1, 2, 3 }, ((HashSet<int>)source));
+        // Order-independent: HashSet<T> enumeration order is not guaranteed,
+        // so compare set contents via SetEquals rather than sequence equality.
+        Assert.True(set.SetEquals(new[] { 1, 2, 3 }));
     }
 
 


### PR DESCRIPTION
## Summary

Five findings from Copilot's third review pass on PR #120 (vNext → main).
Two real bugs (self-aliasing crashes), one perf nit, one test
robustness fix, one csproj de-dup.

## Findings addressed

### Bugs

1. **`RemoveRange` self-aliasing crash.** `list.RemoveRange(list)`
   threw `InvalidOperationException` (mutate-during-enumerate). Now
   snapshots `items` into a temporary `List<T>` when `items` aliases
   `source`. New test covers behaviour: the call empties the collection
   cleanly.
2. **`ReplaceAll` self-aliasing data loss.** `list.ReplaceAll(list)`
   silently wiped the collection — `Clear` drained the source before
   the subsequent `AddRange` enumeration started. Now snapshots
   `items` before `Clear`, making the call a no-op. New test covers it.

### Quality

3. **`RemoveWhere` HashSet fast path closure.** Changed `item =>
   predicate(item)` to `predicate.Invoke` (method group) so the
   `Predicate<T>` conversion doesn't allocate a closure per call.
4. **`AddIfNotContains` HashSet test was order-dependent.** Switched
   from `Assert.Equal(new[]{...}, set)` (sequence equality, depends on
   `HashSet<T>` enumeration order which is not guaranteed) to
   `set.SetEquals(new[]{...})` (order-independent set comparison).
5. **Benchmarks csproj redundant `<Nullable>enable</Nullable>`.**
   Inherited from `Directory.Build.props`; dropped from the csproj
   with a comment pointing at the central default.

## Verification

74 tests pass on net10.0 (72 + 2 new self-aliasing tests). Build
clean (0 warnings, 0 errors) with TWE active.

## Stacking

Targets `vNext`. After this merges, PR #120's diff picks up the fixes
and the unprotected-only merge to main can proceed.