### PR TITLE
fix: A1 PublicAPI baseline + S3267 — unblock PR #120 Stage 2 Windows

### DIFF
--- a/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
+++ b/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Wolfgang.Extensions.ICollection;
 
@@ -379,15 +380,11 @@ public static class ICollectionExtensions
             return set.RemoveWhere(predicate.Invoke);
         }
 
-        var toRemove = new List<T>();
-        foreach (var item in source)
-        {
-            if (predicate(item))
-            {
-                toRemove.Add(item);
-            }
-        }
-
+        // Materialise matches before mutating so the underlying collection
+        // can be modified safely without invalidating the enumerator.
+        // Using Where + ToList here keeps Sonar S3267 happy and reads
+        // closer to the intent than the manual filter loop.
+        var toRemove = source.Where(predicate).ToList();
         foreach (var item in toRemove)
         {
             source.Remove(item);

--- a/src/Wolfgang.Extensions.ICollection/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Extensions.ICollection/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Wolfgang.Extensions.ICollection/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Extensions.ICollection/PublicAPI.Unshipped.txt
@@ -1,0 +1,11 @@
+#nullable enable
+Wolfgang.Extensions.ICollection.ICollectionExtensions
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.AddIfNotContains<T>(this System.Collections.Generic.ICollection<T>! source, System.Collections.Generic.IEnumerable<T>! items) -> int
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.AddIfNotContains<T>(this System.Collections.Generic.ICollection<T>! source, T item) -> bool
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.AddRange<T>(this System.Collections.Generic.ICollection<T>! source, System.Collections.Generic.IEnumerable<T>! items) -> void
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.AddRangeIf<T>(this System.Collections.Generic.ICollection<T>! source, System.Collections.Generic.IEnumerable<T>! items, System.Func<T, bool>! predicate) -> void
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.IsEmpty<T>(this System.Collections.Generic.ICollection<T>! source) -> bool
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.IsNotEmpty<T>(this System.Collections.Generic.ICollection<T>! source) -> bool
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.RemoveRange<T>(this System.Collections.Generic.ICollection<T>! source, System.Collections.Generic.IEnumerable<T>! items) -> void
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.RemoveWhere<T>(this System.Collections.Generic.ICollection<T>! source, System.Func<T, bool>! predicate) -> int
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.ReplaceAll<T>(this System.Collections.Generic.ICollection<T>! source, System.Collections.Generic.IEnumerable<T>! items) -> void


### PR DESCRIPTION
## Summary

Stage 2 Windows CI on PR #120 surfaced two CI-only blockers that
local Release builds didn't trip. Both fixed here.

## Findings

### 1. PublicApiAnalyzer RS0016 / RS0037

The analyzer is wired in via `Directory.Build.props` (CI3 canonical
work), but the src project ships without `PublicAPI.*.txt`. v3.3.4
is supposed to self-disable when `AdditionalFiles` are missing, but
in practice it still surfaces RS0016 on certain TFMs.

Added the canonical A1 baseline:

- `PublicAPI.Shipped.txt` — `#nullable enable` header only. Nothing
  promoted yet; this is the v0.3.0-prep state.
- `PublicAPI.Unshipped.txt` — `#nullable enable` header plus the 9
  public methods (`AddRange`, `IsEmpty`, `IsNotEmpty`, `RemoveRange`,
  `AddRangeIf`, `RemoveWhere`, `ReplaceAll`, `AddIfNotContains` single
  + bulk) and the `ICollectionExtensions` class declaration.

Promotion of `Unshipped → Shipped` happens at the v0.3.0 release-prep
step (matches the DateTime-Extensions pattern).

### 2. Sonar S3267 — Loops should be simplified using Where

`RemoveWhere`'s non-HashSet path filtered with a manual foreach +
if. Refactored to `source.Where(predicate).ToList()` — same
materialise-then-mutate behaviour, reads closer to the intent.
Added `using System.Linq;` to support it.

## Verification

- Build: 0 warnings, 0 errors (Release, TWE active)
- Tests: 74 passing on net10.0 (no behavioural change)

## Stacking

Targets `vNext`. After merge, PR #120 picks both fixes up and Stage 2
Windows should pass cleanly. Closes #108 (PublicApiAnalyzers
baseline).