### PR TITLE
fix: Stage 2 — refactor 2 more S3267 loops PR #136 missed

### DIFF
--- a/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
+++ b/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
@@ -319,12 +319,9 @@ public static class ICollectionExtensions
             throw new ArgumentNullException(nameof(predicate));
         }
 
-        foreach (var item in items)
+        foreach (var item in items.Where(predicate))
         {
-            if (predicate(item))
-            {
-                source.Add(item);
-            }
+            source.Add(item);
         }
     }
 
@@ -524,14 +521,10 @@ public static class ICollectionExtensions
             throw new ArgumentNullException(nameof(items));
         }
 
-        var added = 0;
-        foreach (var item in items)
-        {
-            if (source.AddIfNotContains(item))
-            {
-                added++;
-            }
-        }
-        return added;
+        // Count() with a side-effecting predicate: AddIfNotContains returns
+        // true exactly for items it actually added, so the count is the
+        // number of newly added items. This replaces a manual foreach +
+        // counter that S3267 (Sonar) flags as a Where-able pattern.
+        return items.Count(source.AddIfNotContains);
     }
 }


### PR DESCRIPTION
## Summary

PR #136 only refactored `RemoveWhere`. Stage 2 Windows on PR #120
then surfaced S3267 firing in two more methods that share the same
manual `foreach` + `if` shape:

| Method | Old pattern | New |
|---|---|---|
| `AddRangeIf` | `foreach (var x in items) if (predicate(x)) source.Add(x);` | `foreach (var x in items.Where(predicate)) source.Add(x);` |
| `AddIfNotContains(IEnumerable<T>)` | manual counter loop calling `source.AddIfNotContains(item)` | `return items.Count(source.AddIfNotContains);` (side-effecting predicate; returns true exactly for items added) |

## Verification

- Build: 0 warnings, 0 errors (Release, TWE active)
- Tests: 74 passing on net10.0 — no behavioural change

## Stacking

Targets `vNext`. After this merges, Stage 2 Windows on PR #120 should
clear and the unprotected merge to main can proceed.