### PR TITLE
fix: PublicAPI promote + 2 self-aliasing guards + opt non-src out of analyzer

### DIFF
--- a/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj
@@ -19,6 +19,14 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
 
+  <!-- PublicApiAnalyzers ships from Directory.Build.props but only library
+       projects under src/ should be tracked for breaking-change detection.
+       Benchmarks have no shippable public surface — opt out so RS0016
+       doesn't fire on [Benchmark] methods. -->
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" ExcludeAssets="analyzers" />
+  </ItemGroup>
+
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
 
 </Project>

--- a/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
+++ b/src/Wolfgang.Extensions.ICollection/ICollectionExtensions.cs
@@ -82,6 +82,16 @@ public static class ICollectionExtensions
             throw new ArgumentNullException(nameof(items));
         }
 
+        // Self-aliasing guard: 'list.AddRange(list)' would mutate the
+        // collection during the foreach below, which most BCL enumerators
+        // reject with InvalidOperationException. Snapshot first so the
+        // loop sees a stable view; the effective behaviour is "append a
+        // copy of the current contents to the collection".
+        if (ReferenceEquals(items, source))
+        {
+            items = new List<T>(source);
+        }
+
         // Pre-allocate capacity on the target when it's a List<T> (the only
         // ICollection<T> with a settable Capacity) and items exposes Count
         // up-front via ICollection<T>. Both conditions must hold; without
@@ -317,6 +327,14 @@ public static class ICollectionExtensions
         if (predicate is null)
         {
             throw new ArgumentNullException(nameof(predicate));
+        }
+
+        // Self-aliasing guard: snapshot when items === source so the
+        // Where + foreach below doesn't trip the mutate-during-enumerate
+        // contract on most BCL enumerators.
+        if (ReferenceEquals(items, source))
+        {
+            items = new List<T>(source);
         }
 
         foreach (var item in items.Where(predicate))

--- a/src/Wolfgang.Extensions.ICollection/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Extensions.ICollection/PublicAPI.Shipped.txt
@@ -1,1 +1,11 @@
 #nullable enable
+Wolfgang.Extensions.ICollection.ICollectionExtensions
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.AddIfNotContains<T>(this System.Collections.Generic.ICollection<T>! source, System.Collections.Generic.IEnumerable<T>! items) -> int
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.AddIfNotContains<T>(this System.Collections.Generic.ICollection<T>! source, T item) -> bool
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.AddRange<T>(this System.Collections.Generic.ICollection<T>! source, System.Collections.Generic.IEnumerable<T>! items) -> void
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.AddRangeIf<T>(this System.Collections.Generic.ICollection<T>! source, System.Collections.Generic.IEnumerable<T>! items, System.Func<T, bool>! predicate) -> void
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.IsEmpty<T>(this System.Collections.Generic.ICollection<T>! source) -> bool
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.IsNotEmpty<T>(this System.Collections.Generic.ICollection<T>! source) -> bool
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.RemoveRange<T>(this System.Collections.Generic.ICollection<T>! source, System.Collections.Generic.IEnumerable<T>! items) -> void
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.RemoveWhere<T>(this System.Collections.Generic.ICollection<T>! source, System.Func<T, bool>! predicate) -> int
+static Wolfgang.Extensions.ICollection.ICollectionExtensions.ReplaceAll<T>(this System.Collections.Generic.ICollection<T>! source, System.Collections.Generic.IEnumerable<T>! items) -> void

--- a/src/Wolfgang.Extensions.ICollection/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Extensions.ICollection/PublicAPI.Unshipped.txt
@@ -1,11 +1,1 @@
 #nullable enable
-Wolfgang.Extensions.ICollection.ICollectionExtensions
-static Wolfgang.Extensions.ICollection.ICollectionExtensions.AddIfNotContains<T>(this System.Collections.Generic.ICollection<T>! source, System.Collections.Generic.IEnumerable<T>! items) -> int
-static Wolfgang.Extensions.ICollection.ICollectionExtensions.AddIfNotContains<T>(this System.Collections.Generic.ICollection<T>! source, T item) -> bool
-static Wolfgang.Extensions.ICollection.ICollectionExtensions.AddRange<T>(this System.Collections.Generic.ICollection<T>! source, System.Collections.Generic.IEnumerable<T>! items) -> void
-static Wolfgang.Extensions.ICollection.ICollectionExtensions.AddRangeIf<T>(this System.Collections.Generic.ICollection<T>! source, System.Collections.Generic.IEnumerable<T>! items, System.Func<T, bool>! predicate) -> void
-static Wolfgang.Extensions.ICollection.ICollectionExtensions.IsEmpty<T>(this System.Collections.Generic.ICollection<T>! source) -> bool
-static Wolfgang.Extensions.ICollection.ICollectionExtensions.IsNotEmpty<T>(this System.Collections.Generic.ICollection<T>! source) -> bool
-static Wolfgang.Extensions.ICollection.ICollectionExtensions.RemoveRange<T>(this System.Collections.Generic.ICollection<T>! source, System.Collections.Generic.IEnumerable<T>! items) -> void
-static Wolfgang.Extensions.ICollection.ICollectionExtensions.RemoveWhere<T>(this System.Collections.Generic.ICollection<T>! source, System.Func<T, bool>! predicate) -> int
-static Wolfgang.Extensions.ICollection.ICollectionExtensions.ReplaceAll<T>(this System.Collections.Generic.ICollection<T>! source, System.Collections.Generic.IEnumerable<T>! items) -> void

--- a/tests/Wolfgang.Extensions.ICollection.Tests.Unit/ICollectionExtensionTests.cs
+++ b/tests/Wolfgang.Extensions.ICollection.Tests.Unit/ICollectionExtensionTests.cs
@@ -270,6 +270,19 @@ public class ICollectionExtensionTests
 
 
 
+    [Fact]
+    public void AddRange_when_items_is_same_instance_as_source_appends_snapshot()
+    {
+        // Self-aliasing guard: 'list.AddRange(list)' must snapshot items
+        // before mutating source; otherwise the foreach below trips the
+        // mutate-during-enumerate contract on List<T>'s enumerator.
+        ICollection<int> source = new List<int> { 1, 2, 3 };
+        source.AddRange(source);
+        Assert.Equal(new[] { 1, 2, 3, 1, 2, 3 }, source);
+    }
+
+
+
     // =========================================================================
     // IsEmpty tests
     // =========================================================================
@@ -619,6 +632,20 @@ public class ICollectionExtensionTests
         ICollection<int> source = new List<int> { 0 };
         source.AddRangeIf(new[] { 1, 2, 3 }, _ => false);
         Assert.Equal(new[] { 0 }, source);
+    }
+
+
+
+    [Fact]
+    public void AddRangeIf_when_items_is_same_instance_as_source_appends_filtered_snapshot()
+    {
+        // Self-aliasing guard: 'list.AddRangeIf(list, predicate)' must
+        // snapshot items before enumerating; otherwise the Where +
+        // foreach would trip the mutate-during-enumerate contract when
+        // a matching item is appended.
+        ICollection<int> source = new List<int> { 1, 2, 3, 4 };
+        source.AddRangeIf(source, n => n % 2 == 0);
+        Assert.Equal(new[] { 1, 2, 3, 4, 2, 4 }, source);
     }
 
 

--- a/tests/Wolfgang.Extensions.ICollection.Tests.Unit/Wolfgang.Extensions.ICollection.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.ICollection.Tests.Unit/Wolfgang.Extensions.ICollection.Tests.Unit.csproj
@@ -11,6 +11,15 @@
         <Copyright>Copyright 2026 Chris Wolfgang</Copyright>
     </PropertyGroup>
 
+    <!-- PublicApiAnalyzers is wired into Directory.Build.props (A1/CI3
+         canonical), but only library projects under src/ should be
+         subjected to public-API tracking. Override here to drop the
+         analyzer assets on this test project so RS0016 / RS0037 don't
+         fire on every [Fact] method. -->
+    <ItemGroup>
+        <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" ExcludeAssets="analyzers" />
+    </ItemGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\..\src\Wolfgang.Extensions.ICollection\Wolfgang.Extensions.ICollection.csproj" />
     </ItemGroup>


### PR DESCRIPTION
## Summary

Four findings on PR #120 — two Copilot self-aliasing bugs, two
PublicAPI organization findings, plus the **Stage 2 Windows failure
root cause** identified: the PublicApiAnalyzer was firing on the test
project (RS0016 on every `[Fact]`).

## Findings

### Self-aliasing crashes (2 new methods)

1. **`AddRange`** — `list.AddRange(list)` would have tripped
   `InvalidOperationException` from `List<T>`'s enumerator. Added
   `ReferenceEquals(items, source)` snapshot guard. New test covers it.
2. **`AddRangeIf`** — same fix, same shape. New test covers it.

`RemoveRange`, `ReplaceAll`, `RemoveWhere` already had the guard from
the previous round (#135 + #136).

### PublicAPI baseline organization

Copilot noted that an empty `Shipped.txt` with everything in
`Unshipped.txt` defeats breaking-change detection — the analyzer
compares the live surface against `Shipped`, so removals/changes from
the shipped contract aren't flagged.

Since this stack ships as **v0.3.0**:
- `PublicAPI.Shipped.txt` now contains the 9 public methods +
  `ICollectionExtensions` class declaration (the v0.3.0 contract)
- `PublicAPI.Unshipped.txt` is back to just `#nullable enable`

This matches the DateTime-Extensions release-prep pattern.

### Stage 2 Windows root cause fix

The `Directory.Build.props` `PublicApiAnalyzers` `PackageReference`
loads on every importing project — including tests + benchmarks —
which surfaced RS0016 on every test method. The DBP comment says
"library projects under src/ should opt in; test / example /
benchmark projects should not", but the implementation was relying on
the analyzer self-disabling when `AdditionalFiles` are absent. On
multiple TFMs the analyzer fires anyway.

Added `<PackageReference Update="...PublicApiAnalyzers"
ExcludeAssets="analyzers" />` overrides in both the test and the
benchmarks csproj. The shippable library surface is still tracked.

## Verification

- Build: 0 warnings, 0 errors (Release, TWE active)
- Tests: 76 passing on net10.0 (74 + 2 new self-aliasing)

## Stacking

Targets `vNext`. After merge, Stage 2 Windows on PR #120 should clear
and the unprotected merge to main can proceed.