### PR TITLE
fix: NoWarn PublicApi rules on test+benchmark — actually unblock Stage 2

### DIFF
--- a/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj
@@ -9,6 +9,14 @@
          (canonical fleet-wide default). Redefining it here would duplicate
          the centralized setting and could drift over time. -->
     <IsPackable>false</IsPackable>
+
+    <!-- PublicApiAnalyzers ships from Directory.Build.props but only library
+         projects under src/ should be tracked for breaking-change detection.
+         Benchmarks have no shippable public surface — NoWarn fully
+         suppresses RS0016/etc on this project. (ExcludeAssets="analyzers"
+         on the Update reference proved unreliable across TFMs because
+         the DBP's IncludeAssets wins the merge.) -->
+    <NoWarn>$(NoWarn);RS0016;RS0017;RS0024;RS0026;RS0027;RS0036;RS0037;RS0041</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,14 +25,6 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-  </ItemGroup>
-
-  <!-- PublicApiAnalyzers ships from Directory.Build.props but only library
-       projects under src/ should be tracked for breaking-change detection.
-       Benchmarks have no shippable public surface — opt out so RS0016
-       doesn't fire on [Benchmark] methods. -->
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" ExcludeAssets="analyzers" />
   </ItemGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->

--- a/tests/Wolfgang.Extensions.ICollection.Tests.Unit/Wolfgang.Extensions.ICollection.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.ICollection.Tests.Unit/Wolfgang.Extensions.ICollection.Tests.Unit.csproj
@@ -9,16 +9,16 @@
         <IsTestProject>true</IsTestProject>
 
         <Copyright>Copyright 2026 Chris Wolfgang</Copyright>
-    </PropertyGroup>
 
-    <!-- PublicApiAnalyzers is wired into Directory.Build.props (A1/CI3
-         canonical), but only library projects under src/ should be
-         subjected to public-API tracking. Override here to drop the
-         analyzer assets on this test project so RS0016 / RS0037 don't
-         fire on every [Fact] method. -->
-    <ItemGroup>
-        <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" ExcludeAssets="analyzers" />
-    </ItemGroup>
+        <!-- PublicApiAnalyzers is wired into Directory.Build.props (A1/CI3
+             canonical), but only library projects under src/ should be
+             subjected to public-API tracking. The `Update="..."
+             ExcludeAssets="analyzers"` approach proved unreliable across
+             TFMs because the DBP's `IncludeAssets` wins the merge. Use
+             NoWarn instead — fully suppresses the analyzer's diagnostics
+             on this test project without disturbing the package import. -->
+        <NoWarn>$(NoWarn);RS0016;RS0017;RS0024;RS0026;RS0027;RS0036;RS0037;RS0041</NoWarn>
+    </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Wolfgang.Extensions.ICollection\Wolfgang.Extensions.ICollection.csproj" />


### PR DESCRIPTION
## Summary

PR #138 tried `<PackageReference Update="...PublicApiAnalyzers"
ExcludeAssets="analyzers" />`. That **didn't work** — CI still showed
RS0016 firing on every `[Fact]` after the merge. The
`Directory.Build.props` `IncludeAssets` wins the merge, so the
analyzer continues to load on test/benchmark projects even after the
override.

Switched to `NoWarn` for the PublicAPI rule set
(`RS0016/RS0017/RS0024/RS0026/RS0027/RS0036/RS0037/RS0041`). The
analyzer still loads but its diagnostics are suppressed, which is
the effect we wanted from the start. The shippable library surface
under `src/` is untouched and still tracked.

## Local verification (full Stage 2 matrix, before push)

- `dotnet restore` + `dotnet build -c Release` across all 13 test TFMs
  (`net462`, `net47`, `net471`, `net472`, `net48`, `net481`,
  `netcoreapp3.1`, `net5.0`–`net10.0`): **0 warnings, 0 errors**.
- `dotnet test --framework <tfm>` on `net10.0`, `net9.0`, `net8.0`,
  `net6.0`, `net462`, `netcoreapp3.1`: **76/76 passing** on each.

## Stacking

Targets `vNext`. After merge, Stage 2 Windows on PR #120 should
finally clear and the unprotected merge to main can proceed.