### PR TITLE
chore: prep CHANGELOG for v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `RemoveRange<T>(this ICollection<T>, IEnumerable<T>)` — removes one
-  occurrence of each listed item from the source collection.
-- `AddRangeIf<T>(this ICollection<T>, IEnumerable<T>, Func<T, bool>)` —
-  adds items that satisfy the predicate.
-- `RemoveWhere<T>(this ICollection<T>, Func<T, bool>) -> int` — removes
-  every item matching the predicate; returns the count removed. Safe
-  for any `ICollection<T>` (materialises matches into a temp list
-  before mutating).
-- `ReplaceAll<T>(this ICollection<T>, IEnumerable<T>)` — clears the
-  collection then appends every item from the new sequence.
-- `AddIfNotContains<T>(this ICollection<T>, T) -> bool` — adds a
-  single item only if it is not already present; returns whether the
-  add happened. Generalises `HashSet<T>.Add`'s Boolean return to every
-  `ICollection<T>`.
-- `AddIfNotContains<T>(this ICollection<T>, IEnumerable<T>) -> int` —
-  bulk overload; returns the count actually added.
-
 ### Changed
 
 ### Deprecated
@@ -35,6 +18,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [0.3.0] - 2026-05-30
+
+### Added
+
+- `RemoveRange<T>(this ICollection<T>, IEnumerable<T>)` — removes one
+  occurrence of each listed item from the source collection.
+- `AddRangeIf<T>(this ICollection<T>, IEnumerable<T>, Func<T, bool>)` —
+  adds items that satisfy the predicate.
+- `RemoveWhere<T>(this ICollection<T>, Func<T, bool>) -> int` — removes
+  every item matching the predicate; returns the count removed. Uses
+  `HashSet<T>.RemoveWhere` as a fast path for `HashSet<T>` consumers
+  and falls back to a snapshot-then-remove pattern for every other
+  `ICollection<T>`.
+- `ReplaceAll<T>(this ICollection<T>, IEnumerable<T>)` — clears the
+  collection then appends every item from the new sequence.
+- `AddIfNotContains<T>(this ICollection<T>, T) -> bool` — adds a
+  single item only if it is not already present; returns whether the
+  add happened. Uses `ISet<T>.Add` as a fast path for set consumers
+  so the call is a single lookup; otherwise generalises the
+  `HashSet<T>.Add` Boolean return to every `ICollection<T>`.
+- `AddIfNotContains<T>(this ICollection<T>, IEnumerable<T>) -> int` —
+  bulk overload; returns the count actually added.
+- `PublicAPI.Shipped.txt` baseline now tracks the full public surface
+  via the `Microsoft.CodeAnalysis.PublicApiAnalyzers` package. Future
+  surface changes will surface as RS0016 / RS0017 at build time.
+- `CHANGELOG.md`, populated for both `0.2.0` and `0.3.0`.
+- `benchmarks/Wolfgang.Extensions.ICollection.Benchmarks` —
+  BenchmarkDotNet baseline covering `AddRange` (fast-path vs slow-path)
+  and `IsEmpty` / `IsNotEmpty`. Published to gh-pages via the new
+  `benchmarks.yaml` workflow.
+
+### Changed
+
+- Self-aliasing on `AddRange`, `AddRangeIf`, `RemoveRange`, and
+  `ReplaceAll` (passing the same collection as both `source` and
+  `items`) is now safe: each method snapshots `items` via
+  `ReferenceEquals` before mutating, so the call no longer trips
+  `InvalidOperationException` from a mutate-during-enumerate
+  enumerator. `AddRange(list, list)` now appends a copy of the
+  current contents; `ReplaceAll(list, list)` is a no-op;
+  `RemoveRange(list, list)` empties the collection.
+- README now documents the full nine-method surface in a single
+  reference table; multi-target framework list matches the actual
+  shipped TFMs (`netstandard2.0`, `netstandard2.1`, `net8.0`,
+  `net9.0`, `net10.0`).
+
+### Fixed
+
+- `<AssemblyVersion>` is now explicitly pinned to `1.0.0.0` in the
+  csproj (paired with `<FileVersion>$(Version).0</FileVersion>`).
+  Without this, the canonical CI3 metadata sweep would have let the
+  SDK derive `AssemblyVersion` from `<Version>` on every minor bump,
+  changing the assembly's binding identity and forcing .NET Framework
+  consumers onto binding redirects.
 
 ## [0.2.0] - 2026-05-01
 
@@ -53,5 +91,6 @@ Initial public NuGet release.
 - README content packaged into the NuGet `.nupkg` so it renders on the
   package's nuget.org page.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/ICollection-Extensions/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/ICollection-Extensions/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/Chris-Wolfgang/ICollection-Extensions/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Chris-Wolfgang/ICollection-Extensions/releases/tag/v0.2.0


### PR DESCRIPTION
## Summary

Release-prep PR: promotes the `[Unreleased]` entries into a dated
`## [0.3.0] - 2026-05-30` section ahead of pushing the `v0.3.0` tag.

## What's in the v0.3.0 entry

### Added
- 6 new extension methods (`RemoveRange`, `AddRangeIf`, `RemoveWhere`,
  `ReplaceAll`, `AddIfNotContains` ×2)
- `PublicAPI.Shipped.txt` baseline tracking the full public surface
- `CHANGELOG.md` (populated for both 0.2.0 and 0.3.0)
- BenchmarkDotNet baseline + `benchmarks.yaml` workflow

### Changed
- Self-aliasing snapshot guards on `AddRange`, `AddRangeIf`,
  `RemoveRange`, `ReplaceAll`
- README API table now documents the full nine-method surface; TFM
  list matches the actual shipped TFMs

### Fixed
- `<AssemblyVersion>1.0.0.0</AssemblyVersion>` pin + `<FileVersion>$(Version).0</FileVersion>`
  (C4 binding-stability fix; .NET Framework consumers no longer need
  binding redirects on every minor bump)

`[Unreleased]` reset to the empty Keep-a-Changelog template; compare-
link footer extended with `v0.2.0...v0.3.0` and `v0.3.0...HEAD`.

## Verification

- Build: 0/0 in Release with TWE active
- Tests: 77/77 on net10.0

## After merge

1. Tag `v0.3.0` on the new main HEAD
2. Push tag
3. Publish a GitHub Release for `v0.3.0` → `release.yaml` fires
4. Verify NuGet + versioned docs