### PR TITLE
fix(ci): benchmarks.yaml — hashFiles() at job-level if breaks workflow parse

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -39,14 +39,6 @@ jobs:
     name: Run BenchmarkDotNet & publish chart
     runs-on: ubuntu-latest
 
-    # Skip the run when the benchmark project isn't yet in the tree on
-    # main. The workflow ships in the protected-files sync ahead of the
-    # feature stack that introduces the project, so during that brief
-    # window every qualifying push to main would otherwise fail at the
-    # 'dotnet restore' step. hashFiles() returns '' when the path glob
-    # matches nothing.
-    if: hashFiles('benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj') != ''
-
     permissions:
       # Required to push the rendered chart + history to the gh-pages branch.
       contents: write
@@ -57,19 +49,47 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Detect benchmark project
+        # Gracefully skip the rest of the job when the benchmark csproj
+        # isn't in the tree on main. The workflow may ship via the
+        # canonical protected-files sync ahead of the feature stack that
+        # introduces the project, so during that window every qualifying
+        # push to main would otherwise fail at 'dotnet restore'.
+        #
+        # NOTE: hashFiles() is only available in step-level `if:`
+        # expressions and `with:` parameters — putting it on the job-level
+        # `if:` makes the workflow fail to parse with
+        # "Unrecognized function: 'hashFiles'". We set a step output
+        # instead and gate subsequent steps on it.
+        id: detect
+        shell: bash
+        run: |
+          csproj='benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj'
+          if [ -f "$csproj" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Benchmark project found: $csproj"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Benchmark project '$csproj' not present; skipping the run."
+          fi
+
       - name: Setup .NET
+        if: steps.detect.outputs.exists == 'true'
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             10.0.x
 
       - name: Restore
+        if: steps.detect.outputs.exists == 'true'
         run: dotnet restore benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj
 
       - name: Build (Release)
+        if: steps.detect.outputs.exists == 'true'
         run: dotnet build -c Release --no-restore benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/Wolfgang.Extensions.ICollection.Benchmarks.csproj
 
       - name: Run benchmarks
+        if: steps.detect.outputs.exists == 'true'
         working-directory: benchmarks/Wolfgang.Extensions.ICollection.Benchmarks
         # ShortRun keeps total runtime small (~3-5 min). GitHub-hosted runners
         # are noisy, so chart trends are reliable for allocations and double-digit
@@ -77,6 +97,7 @@ jobs:
         run: dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
 
       - name: Merge per-class BDN reports
+        if: steps.detect.outputs.exists == 'true'
         id: locate
         working-directory: benchmarks/Wolfgang.Extensions.ICollection.Benchmarks
         run: |
@@ -102,6 +123,7 @@ jobs:
           echo "report=benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
 
       - name: Publish chart to gh-pages
+        if: steps.detect.outputs.exists == 'true'
         # Pinned to v1.22.1 commit per repo convention (third-party actions
         # publishing to gh-pages are pinned by SHA, not mutable tag).
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba  # v1.22.1


### PR DESCRIPTION
## Summary

The benchmarks.yaml workflow has been failing on every push to main
since it shipped. The GitHub UI showed *"This run likely failed
because of a workflow file issue"* and `gh run view` returned zero
jobs / no logs.

Reproduced via `gh workflow run`:

```
HTTP 422: Invalid Argument - failed to parse workflow:
(Line: 48, Col: 9): Unrecognized function: 'hashFiles'.
```

**Root cause:** GitHub's expression evaluator rejects `hashFiles()` in
a job-level `if:` condition. The function is only valid in **step-
level** `if:` expressions and `with:` parameters.

## Fix

Replaced the job-level guard with:

1. A `Detect benchmark project` first step that uses plain bash
   (`[ -f "$csproj" ]`) to set `exists=true|false` as a step output.
2. Step-level `if: steps.detect.outputs.exists == 'true'` on every
   subsequent step (`Setup .NET`, `Restore`, `Build`, `Run benchmarks`,
   `Merge per-class BDN reports`, `Publish chart to gh-pages`).

When the benchmark project isn't present the job still completes
green (all subsequent steps skipped, `::notice::` emitted to make the
skip visible in the run summary).

Added a comment block in the workflow spelling out the pitfall so a
future contributor doesn't reintroduce the same parse failure.

## Verification

`gh workflow run benchmarks.yaml --ref fix/benchmarks-hashfiles-job-level`
was accepted (run `26727959154` started executing — proves the
workflow now parses cleanly).

## Fleet follow-up

This same broken pattern likely shipped in `benchmarks.yaml` for every
canonical-sync target (DateTime-Extensions has the same workflow).
Once this fix lands, a bulk-repo-pr fan-out should propagate it.