### PR TITLE
docs: README analyzer count + CHANGELOG v0.3.0 date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [0.3.0] - 2026-05-30
+## [0.3.0] - 2026-05-31
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Self-aliasing is safe by construction: `list.AddRange(list)` snapshots the sourc
 
 ## 🔍 Code Quality & Static Analysis
 
-This project enforces **strict code quality standards** through **8 specialized analyzers**, an `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` Release gate, and custom async-first rules:
+This project enforces **strict code quality standards** through **8 analyzer rule sets** (7 explicit `PackageReference`s plus the .NET SDK's built-in `Microsoft.CodeAnalysis.NetAnalyzers`), an `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` Release gate, and custom async-first rules:
 
 ### Analyzers in Use
 


### PR DESCRIPTION
## Summary

Code-review findings batch 5 of 6 — two doc accuracy nits.

| | Before | After |
|---|---|---|
| README L133 | "8 specialized analyzers" | "8 analyzer rule sets (7 explicit `PackageReference`s plus the SDK's built-in `NetAnalyzers`)" — math agrees with both DBP and the numbered list |
| CHANGELOG L32 | `## [0.3.0] - 2026-05-30` | `## [0.3.0] - 2026-05-31` (matches the v0.3.0 git tag date) |

## Stacking
Bases on `fix/copilot-instructions-sync` (PR #151).