### PR TITLE
benchmarks: cover the 6 missing public methods

### DIFF
--- a/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/ICollectionExtensionsBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/ICollectionExtensionsBenchmarks.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Wolfgang.Extensions.ICollection;
 
@@ -26,7 +27,12 @@ public class ICollectionExtensionsBenchmarks
     // op so the BDN ShortRun finishes quickly.
     private const int Count = 1024;
 
-    private readonly int[] _itemsToAdd = new int[Count];
+    // Populated with 0..Count-1 — unique values matter because several of
+    // the benchmarks below (notably the HashSet fast-path benchmarks) build
+    // a HashSet<int> from this array and would collapse to a single element
+    // if every entry were the default 0. Distinct values keep the set size
+    // at Count so the fast-path vs slow-path comparison is honest.
+    private readonly int[] _itemsToAdd = Enumerable.Range(0, Count).ToArray();
 
 
 

--- a/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/ICollectionExtensionsBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.ICollection.Benchmarks/ICollectionExtensionsBenchmarks.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using Wolfgang.Extensions.ICollection;
@@ -5,12 +6,12 @@ using Wolfgang.Extensions.ICollection;
 namespace Wolfgang.Extensions.ICollection.Benchmarks;
 
 /// <summary>
-/// Microbenchmarks for the public extension methods. <c>AddRange</c> has
-/// two interesting shapes — the fast path where the target is
-/// <c>List&lt;T&gt;</c> and the appended sequence exposes
-/// <c>ICollection&lt;T&gt;.Count</c> (capacity can be pre-allocated), and
-/// the slow path where the target is some other <c>ICollection&lt;T&gt;</c>
-/// (one-by-one append, no pre-allocation). Every receiver is typed as
+/// Microbenchmarks for the public extension methods. The harness pairs
+/// fast-path and slow-path scenarios per method so the gh-pages chart
+/// surfaces any future regression in the targeted optimizations
+/// (e.g. <c>RemoveWhere</c>'s <c>HashSet&lt;T&gt;</c> branch,
+/// <c>AddIfNotContains</c>'s <c>ISet&lt;T&gt;</c> branch,
+/// <c>AddRange</c>'s pre-allocation branch). Every receiver is typed as
 /// <c>ICollection&lt;T&gt;</c> at the call site so the extension method
 /// wins overload resolution against any concrete-type instance method
 /// (e.g. <c>List&lt;T&gt;.AddRange</c> would otherwise bind first). The
@@ -87,5 +88,174 @@ public class ICollectionExtensionsBenchmarks
 
     [Benchmark]
     public bool IsNotEmpty_on_nonempty_collection() => _itemsToAdd.IsNotEmpty();
-}
 
+
+
+    // -- RemoveRange ------------------------------------------------------
+
+    [Benchmark]
+    public ICollection<int> RemoveRange_List_target()
+    {
+        // Parity with AddRange's List/LinkedList split. List<T>.Remove
+        // is O(n) (LastIndexOf + shift), so RemoveRange across n items
+        // becomes O(n²). Pairing with the LinkedList variant below makes
+        // a future O(1)-set-membership shortcut for RemoveRange visible
+        // in the chart.
+        ICollection<int> target = new List<int>(_itemsToAdd);
+        target.RemoveRange(_itemsToAdd);
+        return target;
+    }
+
+
+
+    [Benchmark]
+    public ICollection<int> RemoveRange_LinkedList_target()
+    {
+        ICollection<int> target = new LinkedList<int>(_itemsToAdd);
+        target.RemoveRange(_itemsToAdd);
+        return target;
+    }
+
+
+
+    // -- AddRangeIf -------------------------------------------------------
+
+    [Benchmark]
+    public ICollection<int> AddRangeIf_all_match()
+    {
+        // Pays the predicate cost per item, then takes the same path as
+        // AddRange. Predicate-always-true measures the upper bound of
+        // the filtered-append cost.
+        ICollection<int> target = new List<int>();
+        target.AddRangeIf(_itemsToAdd, _ => true);
+        return target;
+    }
+
+
+
+    [Benchmark]
+    public ICollection<int> AddRangeIf_none_match()
+    {
+        // Predicate-always-false measures the per-item predicate cost
+        // without any Add() — a regression in predicate dispatch would
+        // appear here without being masked by allocation noise.
+        ICollection<int> target = new List<int>();
+        target.AddRangeIf(_itemsToAdd, _ => false);
+        return target;
+    }
+
+
+
+    // -- RemoveWhere ------------------------------------------------------
+
+    [Benchmark]
+    public int RemoveWhere_fast_path_HashSet_target()
+    {
+        // Fast path: HashSet<T>.RemoveWhere is the native single-pass
+        // implementation. The extension's 'source is HashSet<T>' check
+        // routes here and avoids the temp-list allocation + double pass
+        // the slow path takes.
+        var set = new HashSet<int>(_itemsToAdd);
+        ICollection<int> source = set;
+        return source.RemoveWhere(n => (n & 1) == 0);
+    }
+
+
+
+    [Benchmark]
+    public int RemoveWhere_slow_path_List_target()
+    {
+        // Slow path: List<T> is ICollection<T> but not HashSet<T>, so
+        // the extension materialises matches into a temp list and then
+        // calls source.Remove() per item (List.Remove is O(n)).
+        ICollection<int> source = new List<int>(_itemsToAdd);
+        return source.RemoveWhere(n => (n & 1) == 0);
+    }
+
+
+
+    // -- ReplaceAll -------------------------------------------------------
+
+    [Benchmark]
+    public ICollection<int> ReplaceAll_List_target()
+    {
+        ICollection<int> target = new List<int>(_itemsToAdd);
+        target.ReplaceAll(_itemsToAdd);
+        return target;
+    }
+
+
+
+    [Benchmark]
+    public ICollection<int> ReplaceAll_LinkedList_target()
+    {
+        ICollection<int> target = new LinkedList<int>(_itemsToAdd);
+        target.ReplaceAll(_itemsToAdd);
+        return target;
+    }
+
+
+
+    // -- AddIfNotContains(T) ---------------------------------------------
+
+    [Benchmark]
+    public int AddIfNotContains_single_fast_path_HashSet_target()
+    {
+        // Fast path: ISet<T>.Add is the native single-lookup contract.
+        // The extension routes HashSet<T> through here, skipping the
+        // Contains+Add double-lookup the slow path takes.
+        var set = new HashSet<int>();
+        ICollection<int> target = set;
+        var added = 0;
+        for (var i = 0; i < Count; i++)
+        {
+            if (target.AddIfNotContains(i))
+            {
+                added++;
+            }
+        }
+        return added;
+    }
+
+
+
+    [Benchmark]
+    public int AddIfNotContains_single_slow_path_List_target()
+    {
+        // Slow path: List<T>.Contains is O(n), so this is O(n²) over
+        // the loop. The contrast with the HashSet path above makes the
+        // optimization's value visible in the chart.
+        ICollection<int> target = new List<int>();
+        var added = 0;
+        for (var i = 0; i < Count; i++)
+        {
+            if (target.AddIfNotContains(i))
+            {
+                added++;
+            }
+        }
+        return added;
+    }
+
+
+
+    // -- AddIfNotContains(IEnumerable<T>) --------------------------------
+
+    [Benchmark]
+    public int AddIfNotContains_many_HashSet_target()
+    {
+        // Many-arg path: delegates to single-arg per item, so HashSet
+        // target inherits the same ISet fast path through Count().
+        ICollection<int> target = new HashSet<int>();
+        return target.AddIfNotContains(_itemsToAdd);
+    }
+
+
+
+    [Benchmark]
+    public int AddIfNotContains_many_List_target()
+    {
+        ICollection<int> target = new List<int>();
+        return target.AddIfNotContains(_itemsToAdd);
+    }
+}


### PR DESCRIPTION
## Summary

Of the 9 public methods on `ICollectionExtensions`, only 3 had
benchmarks before this PR — `AddRange`, `IsEmpty`, `IsNotEmpty`.
The other 6 had no coverage:

| Public method | Before | After |
|---|---|---|
| `AddRange<T>(IEnumerable<T>)` | ✅ 2 | ✅ 2 |
| `IsEmpty<T>` | ✅ 2 | ✅ 2 |
| `IsNotEmpty<T>` | ✅ 2 | ✅ 2 |
| `RemoveRange<T>(IEnumerable<T>)` | ❌ | ✅ 2 (List / LinkedList) |
| `AddRangeIf<T>(IEnumerable<T>, Func<T,bool>)` | ❌ | ✅ 2 (all-match / none-match) |
| `RemoveWhere<T>(Func<T,bool>)` | ❌ | ✅ 2 (HashSet fast path / List slow path) |
| `ReplaceAll<T>(IEnumerable<T>)` | ❌ | ✅ 2 (List / LinkedList) |
| `AddIfNotContains<T>(T)` | ❌ | ✅ 2 (HashSet fast path / List slow path) |
| `AddIfNotContains<T>(IEnumerable<T>)` | ❌ | ✅ 2 (HashSet / List) |

## Why this matters

Two of the newly-covered methods (`RemoveWhere`, `AddIfNotContains(T)`)
have **fast-path optimizations** the codebase pays clarity for —
`HashSet<T>.RemoveWhere` and `ISet<T>.Add` shortcuts that skip the
generic `Where + ToList + foreach Remove` / `Contains + Add` slow
paths. Without benchmarks, a refactor that accidentally regresses
either path lands silently. The Stryker mutation disable comments
landed in `fix/build-hygiene` (commit `03b06e6`) describe these
optimizations as "intentional redundant fast paths" — the benchmarks
here are the corresponding evidence that they ARE faster.

Pairs every new benchmark fast-path-vs-slow-path so the gh-pages
chart shows the optimization's value (or its disappearance) at a
glance.

## Verified locally

`dotnet build -c Release benchmarks/...` — 0 warnings, 0 errors
under `<TreatWarningsAsErrors>` Release.

## Stack position

Stacked on `fix/build-hygiene` (which itself stacks back through
PRs #148 → #149 → #150 → #151 → #152 → #153 → #156, all now
clean). Will auto-promote base to `main` as the chain merges.