### PR TITLE
Release v0.3.1: DOCFX-VERSION-PICKER doc + code-review nits + release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,91 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.3.1] - 2026-06-01
+
+Polish release. The public API and runtime behavior are unchanged from
+v0.3.0; this round delivers documentation, examples, tests, benchmarks,
+and canonical workflow updates.
+
+### Added
+
+- `docs/DOCFX-VERSION-PICKER.md` — the canonical 210-line reference
+  for the docs-site version picker (companion to the
+  `docfx_project/public/version-picker.js` /
+  `docfx_project/versions.json` /
+  `.github/version-picker-template.html` triplet that was already
+  shipping).
+- `examples/Wolfgang.Extensions.ICollection.DotNet80.Example1/` and
+  `examples/Wolfgang.Extensions.ICollection.DotNet10.Example1/` —
+  runnable demonstration apps exercising every public extension
+  method against `List<T>`, `HashSet<T>`, `LinkedList<T>`, and
+  `Collection<T>`. The .NET 10 example uses C# 12 collection
+  expressions; the .NET 8 example uses traditional `new[]` syntax.
+- `RemoveWhere_when_source_is_HashSet_uses_native_RemoveWhere` test —
+  closes the previous Stryker `NoCoverage` gap on the HashSet
+  fast-path block.
+- Twelve fast/slow-path-paired benchmarks covering the six public
+  methods that were previously unbenchmarked: `RemoveRange`,
+  `AddRangeIf`, `RemoveWhere`, `ReplaceAll`,
+  `AddIfNotContains<T>(T)`, `AddIfNotContains<T>(IEnumerable<T>)`.
+  Brings benchmark coverage to 9 / 9 public methods. The
+  `_itemsToAdd` test array is now populated with distinct values
+  (`Enumerable.Range(0, Count).ToArray()`) so the HashSet fast-path
+  benchmarks measure a real `Count`-element set, not a single-element
+  deduplication.
+
+### Changed
+
+- XML documentation expanded across `AddRange` / `AddRangeIf` /
+  `RemoveRange` / `ReplaceAll` to describe the self-aliasing
+  `ReferenceEquals` snapshot guard (passing the same collection as
+  both `source` and `items` is now documented as safe).
+- `IsNotEmpty` remarks block — the phrase "self-documenting emptiness
+  check" was inaccurate (the method returns true when `Count > 0`);
+  corrected to "non-emptiness check".
+- README — analyzer count clarified to "8 analyzer rule sets (7
+  explicit `PackageReference`s plus the SDK's built-in
+  `NetAnalyzers`)" with each named.
+- `.github/copilot-instructions.md` — method descriptions resynced
+  with the v0.3.0 fast-path behavior.
+- `CHANGELOG` — the v0.3.0 release date corrected from `2026-05-30`
+  to `2026-05-31` (matches the actual `v0.3.0` tag timestamp).
+- `docfx_project/` — landing page, introduction, getting-started all
+  rewritten for v0.3.0+ content.
+- `.github/workflows/stryker.yaml` — switched to a Windows runner,
+  dropped the per-repo opt-in gate (`stryker-config.json` presence
+  is now the universal signal), comprehensive SDK install list
+  (`3.1.x` through `10.0.x`).
+- `.github/workflows/codeql.yaml` — bumped `github/codeql-action/init`
+  and `analyze` from `@v3` to `@v4` (Node.js 20 → 24 deprecation).
+- `src` and test csprojs — dropped redundant `<Copyright>` (test)
+  and `<Title>$(AssemblyName)</Title>` (src); both inherit from
+  `Directory.Build.props` / MSBuild defaults respectively.
+- `assets/icon.ico` — moved out of the src project directory; the
+  binary is retained as a fleet asset rather than a per-project
+  resource.
+
+### Fixed
+
+- Three Stryker mutation survivors on `ICollectionExtensions.cs`
+  reclassified as intentional via `// Stryker disable all : <reason>`
+  comments: the five redundant defensive null-check blocks
+  (`AddRangeIf` predicate / `RemoveWhere` source+predicate /
+  `ReplaceAll` items / `AddIfNotContains(IEnumerable<T>)` source) and
+  the two redundant optimization fast paths (`RemoveWhere`'s
+  `HashSet<T>` block, `AddIfNotContains<T>(T)`'s `ISet<T>` block).
+  Each annotation documents why the mutated form is observationally
+  indistinguishable from the original (the BCL / slow path throws
+  the same `ArgumentNullException` or produces the same final
+  state). Brings mutation score on `ICollectionExtensions.cs` to
+  100 % on the testable surface.
+- Mis-indented `EmptyStateCases` comment block in the test file —
+  re-aligned to the surrounding 4-space member indentation.
+- `AddRange_when_items_is_large_collection_adds_all_items` —
+  extracted the literal `10_000` into a named
+  `const int LargeBatchCount` so the value lives in one place and
+  the three assertions self-document.
+
 ## [0.3.0] - 2026-05-31
 
 ### Added
@@ -91,6 +176,7 @@ Initial public NuGet release.
 - README content packaged into the NuGet `.nupkg` so it renders on the
   package's nuget.org page.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/ICollection-Extensions/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/ICollection-Extensions/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/Chris-Wolfgang/ICollection-Extensions/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Chris-Wolfgang/ICollection-Extensions/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Chris-Wolfgang/ICollection-Extensions/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,9 +79,12 @@ and canonical workflow updates.
 - `src` and test csprojs — dropped redundant `<Copyright>` (test)
   and `<Title>$(AssemblyName)</Title>` (src); both inherit from
   `Directory.Build.props` / MSBuild defaults respectively.
-- `assets/icon.ico` — moved out of the src project directory; the
-  binary is retained as a fleet asset rather than a per-project
-  resource.
+- `assets/icon.ico` — fleet-asset copy of the icon added alongside
+  the existing `src/Wolfgang.Extensions.ICollection/icon.ico` (which
+  is still referenced by `<ApplicationIcon>` in the csproj and
+  packed into the `.nupkg` via the `<Content Include="icon.ico" />`
+  ItemGroup). The new `assets/` copy mirrors `assets/icon.png` for
+  fleet-wide consistency.
 
 ### Fixed
 

--- a/docs/DOCFX-VERSION-PICKER.md
+++ b/docs/DOCFX-VERSION-PICKER.md
@@ -1,0 +1,210 @@
+# DocFX Version Picker
+
+The docs site shows an in-page version picker (a `<select>` dropdown in
+the header) so readers on any page can jump between published doc
+versions. The picker is a self-contained JavaScript snippet — DocFX's
+`default`/`modern`/`modern-dark` templates don't ship one natively, so
+this repo implements its own.
+
+The same picker is in `repo-template` and fans out unchanged to every
+downstream `.NET` repo in the fleet.
+
+---
+
+## How a reader experiences it
+
+| URL | What happens |
+|---|---|
+| `/<repo>/` | Root redirect → lands on `/<repo>/versions/latest/` (Microsoft Docs-style UX) |
+| `/<repo>/versions/latest/` (or any version) | Real DocFX docs render. The header shows a `<select>` between the app title and the theme toggle, populated from `versions.json` and pre-selecting whichever version the current URL is under. |
+| Pick a different version in the dropdown | Browser navigates to `/<repo>/versions/<picked>/` |
+
+The "latest" alias is filtered out of the dropdown (redundant — the
+highest-numbered `v*` row already represents latest); `versions.json`
+still includes it so external links / scripts can resolve it.
+
+---
+
+## The four moving parts
+
+### 1. `docfx_project/public/version-picker.js`
+
+Browser-side picker (~160 lines). On `DOMContentLoaded`:
+
+- Detects whether the host is `*.github.io` and computes the repo
+  prefix accordingly — same file works on github.io, on
+  `docfx build --serve` localhost, and on CNAME-served custom domains.
+- Fetches `versions.json` from the site root (default browser cache
+  policy — the file changes infrequently).
+- Builds a themed `<select>` (uses Bootstrap CSS variables so it
+  follows DocFX modern's light/dark theme; `color-scheme: light dark`
+  makes the OS-rendered popup readable in both modes).
+- Inserts the picker into the DocFX header using a prioritised anchor
+  list (theme toggle → navbar → search → header); the `header`
+  fallback appends INTO the header, not as a sibling under `<html>`.
+- Strips the gh-pages `/<repo>/` prefix from navigation URLs when
+  off-github.io so localhost / CNAME navigation resolves to
+  `/versions/<v>/` rather than `/<repo>/versions/<v>/`.
+
+Falls back silently (no broken page, no empty dropdown) if
+`versions.json` is missing, malformed, or contains only a `latest`
+alias after filtering.
+
+### 2. `docfx_project/docfx.json`
+
+Two changes from a stock DocFX project:
+
+```jsonc
+"resource": [
+  {
+    "files": [
+      "logo.svg",
+      "images/**",
+      "public/**",         // ← copies version-picker.js into _site/public/
+      "versions.json"      // ← stub for local dev; workflow overwrites on deploy
+    ]
+  }
+],
+
+"globalMetadata": {
+  // ...
+  "_appFooter": "Made with DocFX <script>...</script>"
+  //                              ^ tiny inline bootstrap that computes
+  //                                the site root and lazy-loads
+  //                                /<repo>/public/version-picker.js
+  //                                into document.head. Inline (not
+  //                                external) because _appFooter is a
+  //                                plain string field, not a Liquid
+  //                                template — page-relative paths
+  //                                wouldn't resolve from nested pages
+  //                                like /api/Foo.html.
+}
+```
+
+### 3. `docfx_project/versions.json` (stub)
+
+Committed as `[]` (empty array). The `docfx.yaml` workflow regenerates
+the real `versions.json` at deploy time from the set of actual `v*`
+tags that have versioned docs deployed (D6 derivation) and writes it
+to the gh-pages site root. The empty stub is the fanout-safe default —
+no DateTime-Extensions paths leak into other repos when this folder is
+synced fleet-wide.
+
+**Local picker testing** requires populating `versions.json` manually
+with mock entries (see "Testing locally" below). The picker
+gracefully falls back to "no dropdown" if the stub is empty.
+
+### 4. `.github/version-picker-template.html`
+
+Used by the `docfx.yaml` "Generate version-picker index.html" step.
+Renders an auto-redirect page at the gh-pages root:
+
+- `meta http-equiv="refresh"` for instant redirect
+- `setTimeout` JS backup if meta-refresh is blocked
+- `<noscript>` link covers the everything-else case
+
+`{{TITLE}}` is substituted with the repo name at deploy time;
+`{{VERSION_LIST}}` is intentionally omitted from the template. A missing
+pattern is a true no-op for PowerShell's `-replace` (returns the original
+string unchanged), so the workflow runs unchanged; nothing gets injected
+into the root redirect page because the in-page dropdown is now the
+canonical version-selector UI.
+
+---
+
+## How it gets to gh-pages
+
+```
+push to main / release tag
+  └─ docfx.yaml fires
+       ├─ docfx build  → _site/  (includes public/version-picker.js,
+       │                          inline bootstrap in every page's
+       │                          footer via _appFooter)
+       ├─ Generate versions.json from v* tags → _site/versions.json
+       ├─ Deploy _site/ to gh-pages /versions/<v>/ + /versions/latest/
+       └─ Generate root index.html from version-picker-template.html
+                  → deploy to gh-pages /
+```
+
+Result on gh-pages:
+
+```
+/                      ← redirect to /versions/latest/
+/versions.json         ← available-versions list (drives the picker)
+/versions/latest/      ← latest docs (with picker in header)
+/versions/v1.3.0/      ← versioned docs (with picker)
+/versions/v1.2.0/      ← versioned docs (with picker)
+...
+```
+
+---
+
+## Testing locally
+
+`docfx build --serve` doesn't replicate the gh-pages layout — there's
+no `/versions/<v>/` tree and no auto-generated `versions.json`. To
+exercise the picker locally:
+
+```bash
+cd docfx_project
+
+# Build src first (DocFX metadata needs the assemblies)
+dotnet build ../src/<package>/<package>.csproj -c Release
+
+# Generate API metadata + build site
+docfx metadata
+docfx build
+
+# Drop a mock versions.json with the URLs the picker will navigate to.
+# Use the repo's own /<repo>/versions/<v>/ scheme so the JS's
+# prefix-stripping path is exercised.
+cat > _site/versions.json <<'JSON'
+[
+  { "version": "latest", "url": "/<repo>/versions/latest/" },
+  { "version": "v1.0.0", "url": "/<repo>/versions/v1.0.0/" }
+]
+JSON
+
+# Optionally, copy _site/* into _site/versions/latest/ etc.
+# so the navigation lands on real pages instead of 404s.
+
+# Serve and visit http://localhost:8081/
+docfx serve _site --port 8081
+```
+
+The picker fetches `versions.json` from `/versions.json` (no repo
+prefix on localhost), builds the dropdown, and navigates to
+`/versions/<v>/` on selection (with the `/<repo>/` prefix stripped
+because we're not on github.io).
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Where to look |
+|---|---|---|
+| Dropdown missing entirely | `version-picker.js` not loaded on the page | DevTools → Network. The page should fetch `/<repo>/public/version-picker.js`. If 404, check `docfx.json` `resource.files` includes `public/**`. |
+| Dropdown shows wrong selection | `currentVersion` derivation in the JS didn't find a `/versions/<v>/` segment in the URL | DevTools → Console — log `window.location.pathname` and re-derive |
+| Dropdown empty | `versions.json` fetch failed or returned an array without any non-"latest" entries | DevTools → Network. The page should fetch `/<repo>/versions.json` (or `/versions.json` on localhost) and get a JSON array with `version`+`url` entries. |
+| Popup text invisible (light-on-light or dark-on-dark) | `color-scheme: light dark` missing or Bootstrap CSS vars not loaded | Verify `version-picker.js` is the current version |
+| Picker appears as sibling of `<header>` instead of inside it | Anchor fallback selected `header` with the wrong insertion mode | Verify the anchors table has `['header', 'append']` (not `'before'`) |
+| Root `/` shows old "Select a documentation version" landing page | The `version-picker-template.html` change didn't deploy | Check the workflow run's "Generate version-picker index.html" step output |
+
+For workflow-level issues (failed deploys, stale `versions.json`,
+missing version subtrees), the `docfx.yaml` run's per-step output is
+the canonical place to look. `scripts/Validate-DocsDeploy.sh` runs
+at the end of every deploy and catches structural drift.
+
+---
+
+## Manual recovery for a broken `gh-pages`
+
+If gh-pages ends up in a state the workflow can't repair, **do not run
+a manual cleanup against the gh-pages root** — every versioned subtree
+under `versions/` is unrecoverable once deleted (the source git tag
+still exists, but the rendered HTML would have to be regenerated by
+running `docfx.yaml` once per tag via `workflow_dispatch`).
+
+Safe recovery: re-run `docfx.yaml` with `workflow_dispatch` for each
+affected tag in turn (oldest first). The worktree-based replace
+rebuilds `versions/<tag>/` cleanly without affecting the others.

--- a/docs/DOCFX-VERSION-PICKER.md
+++ b/docs/DOCFX-VERSION-PICKER.md
@@ -114,17 +114,28 @@ canonical version-selector UI.
 
 ## How it gets to gh-pages
 
+`docfx.yaml` is **not** triggered directly by `push` or by pushing a
+tag — it has only `workflow_call` (invoked by `release.yaml` after a
+GitHub Release is published) and `workflow_dispatch` (manual). So
+the actual chain that deploys the picker is:
+
 ```
-push to main / release tag
-  └─ docfx.yaml fires
-       ├─ docfx build  → _site/  (includes public/version-picker.js,
-       │                          inline bootstrap in every page's
-       │                          footer via _appFooter)
-       ├─ Generate versions.json from v* tags → _site/versions.json
-       ├─ Deploy _site/ to gh-pages /versions/<v>/ + /versions/latest/
-       └─ Generate root index.html from version-picker-template.html
-                  → deploy to gh-pages /
+GitHub Release published   (or manual workflow_dispatch)
+  └─ release.yaml fires    (only on the published-release flow)
+       └─ release.yaml → calls docfx.yaml as a reusable workflow
+            └─ docfx.yaml fires
+                 ├─ docfx build  → _site/  (includes public/version-picker.js,
+                 │                          inline bootstrap in every page's
+                 │                          footer via _appFooter)
+                 ├─ Generate versions.json from v* tags → _site/versions.json
+                 ├─ Deploy _site/ to gh-pages /versions/<v>/ + /versions/latest/
+                 └─ Generate root index.html from version-picker-template.html
+                            → deploy to gh-pages /
 ```
+
+A plain `git push` to `main` does **not** redeploy the docs — the
+gh-pages content updates only when a GitHub Release is published
+(or when someone runs `docfx.yaml` manually via the Actions tab).
 
 Result on gh-pages:
 

--- a/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
+++ b/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
-		<Version>0.3.0</Version>
+		<Version>0.3.1</Version>
 		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
 		     do not need to recompile / add binding redirects on every minor/patch
 		     bump. Bump only on a deliberate breaking API change. FileVersion +

--- a/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
+++ b/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
@@ -9,7 +9,7 @@
 		     InformationalVersion (the latter auto-derived from <Version>) carry
 		     the actual release version. -->
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
-		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(Version)', '[-+].*$', '')).0</FileVersion>
+		<FileVersion>$(Version).0</FileVersion>
 		<!-- <Authors> and <Copyright> are inherited from Directory.Build.props
 		     (canonical CI3 defaults). Re-defining them here would duplicate the
 		     fleet-wide values and drift over time. -->

--- a/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
+++ b/src/Wolfgang.Extensions.ICollection/Wolfgang.Extensions.ICollection.csproj
@@ -10,7 +10,6 @@
 		     the actual release version. -->
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace('$(Version)', '[-+].*$', '')).0</FileVersion>
-		<Title>$(AssemblyName)</Title>
 		<!-- <Authors> and <Copyright> are inherited from Directory.Build.props
 		     (canonical CI3 defaults). Re-defining them here would duplicate the
 		     fleet-wide values and drift over time. -->

--- a/tests/Wolfgang.Extensions.ICollection.Tests.Unit/ICollectionExtensionTests.cs
+++ b/tests/Wolfgang.Extensions.ICollection.Tests.Unit/ICollectionExtensionTests.cs
@@ -230,16 +230,17 @@ public class ICollectionExtensionTests
     public void AddRange_when_items_is_large_collection_adds_all_items()
     {
         // Arrange
+        const int LargeBatchCount = 10_000;
         ICollection<int> source = new List<int>();
-        var items = Enumerable.Range(1, 10000);
+        var items = Enumerable.Range(1, LargeBatchCount);
 
         // Act
         source.AddRange(items);
 
         // Assert
-        Assert.Equal(10000, source.Count);
+        Assert.Equal(LargeBatchCount, source.Count);
         Assert.Equal(1, source.First());
-        Assert.Equal(10000, source.Last());
+        Assert.Equal(LargeBatchCount, source.Last());
     }
 
 


### PR DESCRIPTION
## Summary

Original scope: full code review of `main` (post-#148) — surfaced
the missing canonical `DOCFX-VERSION-PICKER.md`, a redundant
`<Title>` csproj element, and a magic-number nit in the tests.

PR #159 (release prep) has since been merged into this branch's
head, so this PR now also carries the v0.3.1 version bump,
CHANGELOG `[0.3.1]` entry, and a follow-up FileVersion simplification
in response to in-PR review.

## Contents

### Code review nits (original scope)
- `docs/DOCFX-VERSION-PICKER.md` — canonical 210-line picker
  reference doc copied in (matches DateTime-Extensions /
  repo-template). Also corrected the "How it gets to gh-pages"
  diagram, which inaccurately suggested push-to-main triggers
  `docfx.yaml` — the workflow is `workflow_call` + `workflow_dispatch`
  only.
- `src/.../Wolfgang.Extensions.ICollection.csproj` — dropped
  redundant `<Title>$(AssemblyName)</Title>` (the default behavior
  when omitted).
- `tests/.../ICollectionExtensionTests.cs` — extracted the literal
  `10_000` in `AddRange_when_items_is_large_collection_adds_all_items`
  into `const int LargeBatchCount`.

### v0.3.1 release prep (merged from #159)
- `<Version>0.3.0</Version>` → `<Version>0.3.1</Version>`
- CHANGELOG `[0.3.1] - 2026-06-01` entry covering everything in
  this PR + the previously-merged #148 (build hygiene) + #157
  (benchmarks).
- CHANGELOG footer compare links updated.

### Follow-up fixes from review on this PR
- `<FileVersion>` simplified — the regex-strip expression was
  protecting against a hypothetical prerelease tag the repo
  doesn't actually ship. Reduced to `<FileVersion>$(Version).0</FileVersion>`;
  verified build still produces `FileVersion=0.3.1.0` on the dll.
- CHANGELOG bullet corrected: `assets/icon.ico` is an additional
  fleet-asset copy of the icon, not a relocation — the icon is
  still at `src/.../icon.ico` and is still packed into the `.nupkg`.

## Verified

- `dotnet build -c Release` — 0 warnings, 0 errors across all 13 TFMs
- `dotnet test -c Release` (net10.0) — 78/78 pass
- Coverage — 100 % line, 100 % branch
- Stryker — 100 % on testable surface (43 ignored by design)
- FileVersion verified post-simplification: 0.3.1.0 on the net10.0 dll

## Merge → tag → release

After this admin-bypass merges:

1. Tag `v0.3.1` on `main`
2. Publish a GitHub Release for `v0.3.1` → `release.yaml` fires →
   pack-and-validate → verify-docs-build → publish-nuget →
   trigger-docs (deploys the picker with the new versioned docs)
3. Verify `Wolfgang.Extensions.ICollection 0.3.1` on NuGet (~5 min
   for index)
4. Verify `chris-wolfgang.github.io/ICollection-Extensions/versions/v0.3.1/`
   resolves and the version-picker dropdown lists v0.3.1