### PR TITLE
Canonical forward-sync: .gitignore (recursive _site/ + api/*.yml rule)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -427,7 +427,13 @@ CoverageReport/
 package-smoke-test/
 nuget-packages/
 
-# DocFX generated files
-docfx_project/_site/
+# DocFX generated files (any depth)
+_site/
 docfx_project/obj/
+# Auto-generated API metadata: `docfx metadata` writes <Type>.yml and toc.yml
+# under docfx_project/api/ for every public type extracted from src/. Keep
+# these out of the repo so a careless `git add -A` after running docfx
+# metadata locally doesn't commit generated files. The hand-written
+# index.md and README.md in api/ are intentionally tracked.
+docfx_project/api/*.yml
 


### PR DESCRIPTION
## Summary

Final piece of the canonical-drift sweep (after #160 / #402 / #403). `.gitignore` had two template improvements not yet in this repo:

1. **Recursive `_site/` rule** — `_site/` (matches DocFX-generated output at any depth) replaces the previous `docfx_project/_site/` (only matches that exact path).
2. **`docfx_project/api/*.yml` rule** — keeps the auto-generated DocFX metadata (`<Type>.yml` / `toc.yml` files produced by `docfx metadata`) out of the repo. Without it, a careless `git add -A` after running `docfx metadata` locally commits generated YAML alongside the intentionally-tracked `index.md` and `README.md` in the api/ folder.

Both bugs would have manifested if anyone ran `docfx metadata` locally — exactly the path the new `docs/DOCFX-VERSION-PICKER.md` documents as the local-repro flow.

## Diff

```
< # DocFX generated files
< docfx_project/_site/
---
> # DocFX generated files (any depth)
> _site/
>
> # Auto-generated API metadata: `docfx metadata` writes <Type>.yml and toc.yml
> # under docfx_project/api/ for every public type extracted from src/. Keep
> # these out of the repo so a careless `git add -A` after running docfx
> # metadata locally doesn't commit generated files. The hand-written
> # index.md and README.md in api/ are intentionally tracked.
> docfx_project/api/*.yml
```

## Stack position

Independent — branched off main. Not protected. Normal merge.