### PR TITLE
docs: sync DOCFX-VERSION-PICKER diagram with corrected two-path version

### DIFF
--- a/docs/DOCFX-VERSION-PICKER.md
+++ b/docs/DOCFX-VERSION-PICKER.md
@@ -134,15 +134,28 @@ The deploy steps that docfx.yaml runs in both cases:
   │                          inline bootstrap in every page's
   │                          footer via _appFooter)
   ├─ Generate versions.json from v* tags → _site/versions.json
-  ├─ Deploy _site/ to gh-pages /versions/<v>/ + /versions/latest/
+  ├─ Deploy _site/ to gh-pages /versions/<v>/  (always)
+  │
+  │  --- The remaining two steps only run when `deploy_as_latest`
+  │      is true (the default; uncheck on workflow_dispatch when
+  │      you're rebuilding an OLDER version and don't want to move
+  │      the "latest" alias):
+  │
+  ├─ Deploy _site/ to gh-pages /versions/latest/   [deploy_as_latest only]
   └─ Generate root index.html from version-picker-template.html
-             → deploy to gh-pages /
+             → deploy to gh-pages /                [deploy_as_latest only]
 ```
 
 A plain `git push` to `main` does **not** redeploy the docs — the
 gh-pages content updates only via Path 1 (publishing a GitHub
 Release) or Path 2 (manually running `docfx.yaml` from the Actions
 tab).
+
+`deploy_as_latest` defaults to true. The escape hatch is for the
+Path 2 manual case where you want to rebuild and republish the
+docs for an older version (e.g. backporting a doc fix to `v1.0.0`)
+without overwriting the `/versions/latest/` alias and the site-root
+index that the picker bootstrap reads.
 
 Result on gh-pages:
 

--- a/docs/DOCFX-VERSION-PICKER.md
+++ b/docs/DOCFX-VERSION-PICKER.md
@@ -116,26 +116,33 @@ canonical version-selector UI.
 
 `docfx.yaml` is **not** triggered directly by `push` or by pushing a
 tag — it has only `workflow_call` (invoked by `release.yaml` after a
-GitHub Release is published) and `workflow_dispatch` (manual). So
-the actual chain that deploys the picker is:
+GitHub Release is published) and `workflow_dispatch` (manual). Two
+paths reach it:
 
 ```
-GitHub Release published   (or manual workflow_dispatch)
-  └─ release.yaml fires    (only on the published-release flow)
+Path 1 — normal: a GitHub Release is published
+  └─ release.yaml fires (on `release: types: [published]`)
        └─ release.yaml → calls docfx.yaml as a reusable workflow
-            └─ docfx.yaml fires
-                 ├─ docfx build  → _site/  (includes public/version-picker.js,
-                 │                          inline bootstrap in every page's
-                 │                          footer via _appFooter)
-                 ├─ Generate versions.json from v* tags → _site/versions.json
-                 ├─ Deploy _site/ to gh-pages /versions/<v>/ + /versions/latest/
-                 └─ Generate root index.html from version-picker-template.html
-                            → deploy to gh-pages /
+            └─ docfx.yaml runs the deploy steps below
+
+Path 2 — manual: a maintainer runs docfx.yaml from the Actions tab
+  └─ docfx.yaml fires directly (on `workflow_dispatch`)
+       └─ docfx.yaml runs the deploy steps below
+
+The deploy steps that docfx.yaml runs in both cases:
+  ├─ docfx build  → _site/  (includes public/version-picker.js,
+  │                          inline bootstrap in every page's
+  │                          footer via _appFooter)
+  ├─ Generate versions.json from v* tags → _site/versions.json
+  ├─ Deploy _site/ to gh-pages /versions/<v>/ + /versions/latest/
+  └─ Generate root index.html from version-picker-template.html
+             → deploy to gh-pages /
 ```
 
 A plain `git push` to `main` does **not** redeploy the docs — the
-gh-pages content updates only when a GitHub Release is published
-(or when someone runs `docfx.yaml` manually via the Actions tab).
+gh-pages content updates only via Path 1 (publishing a GitHub
+Release) or Path 2 (manually running `docfx.yaml` from the Actions
+tab).
 
 Result on gh-pages:
 


### PR DESCRIPTION
## Summary

Closes the single finding from the post-#160/#161 code-review pass.

The 'How it gets to gh-pages' diagram in `docs/DOCFX-VERSION-PICKER.md`
conflated the two workflow trigger paths — showing
`workflow_dispatch` as a parenthetical on the Release path, which
implied manual runs go through `release.yaml`. They don't:
`release.yaml` only triggers on `release: types: [published]`, while
`workflow_dispatch` fires `docfx.yaml` directly.

Split into two explicit paths and factored the shared deploy steps:

```
Path 1 — normal: Release published → release.yaml → docfx.yaml
Path 2 — manual: workflow_dispatch → docfx.yaml directly

The deploy steps that docfx.yaml runs in both cases:
  ├─ docfx build → _site/
  ├─ Generate versions.json
  ├─ Deploy _site/ to gh-pages
  └─ Generate root index.html
```

## Origin

Caught during PR #402's Copilot review on repo-template (where this
doc had the same error) and corrected there. The fix didn't propagate
back to ICollection-Extensions automatically because the file was
already synced from the older canonical before #402 landed. This PR
brings them in line.

## Verified

Just the diagram block reflowed. Repo's only doc with the conflated
diagram; no other paths reference the chain.